### PR TITLE
Expose stylish-haskell as a library

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -16,11 +16,7 @@ import           System.IO.Strict       (readFile)
 
 
 --------------------------------------------------------------------------------
-import           Paths_stylish_haskell  (version)
-import           StylishHaskell
-import           StylishHaskell.Config
-import           StylishHaskell.Step
-import           StylishHaskell.Verbose
+import           Language.Haskell.Stylish
 
 
 --------------------------------------------------------------------------------

--- a/src/Language/Haskell/Stylish.hs
+++ b/src/Language/Haskell/Stylish.hs
@@ -1,0 +1,61 @@
+module Language.Haskell.Stylish
+    ( -- * Run
+      runSteps
+      -- * Steps
+    , imports
+    , languagePragmas
+    , records
+    , tabs
+    , trailingWhitespace
+    , unicodeSyntax
+      -- ** Data types
+    , Imports.Align (..)
+    , LanguagePragmas.Style (..)
+      -- ** Helpers
+    , stepName
+      -- * Config
+    , module StylishHaskell.Config
+      -- * Misc
+    , module StylishHaskell.Verbose
+    , version
+    , Lines
+    , Step
+    ) where
+
+import StylishHaskell
+import StylishHaskell.Config
+import StylishHaskell.Step
+import StylishHaskell.Verbose
+import Paths_stylish_haskell  (version)
+
+import qualified StylishHaskell.Step.Imports as Imports
+import qualified StylishHaskell.Step.LanguagePragmas as LanguagePragmas
+import qualified StylishHaskell.Step.Records as Records
+import qualified StylishHaskell.Step.Tabs as Tabs
+import qualified StylishHaskell.Step.TrailingWhitespace as TrailingWhitespace
+import qualified StylishHaskell.Step.UnicodeSyntax as UnicodeSyntax
+
+imports :: Int -- ^ columns
+        -> Imports.Align
+        -> Step
+imports = Imports.step
+
+languagePragmas :: Int -- ^ columns
+                -> LanguagePragmas.Style
+                -> Bool -- ^ remove redundant?
+                -> Step
+languagePragmas = LanguagePragmas.step
+
+records :: Step
+records = Records.step
+
+tabs :: Int -- ^ number of spaces
+     -> Step
+tabs = Tabs.step
+
+trailingWhitespace :: Step
+trailingWhitespace = TrailingWhitespace.step
+
+unicodeSyntax :: Bool -- ^ add language pragma?
+              -> Step
+unicodeSyntax = UnicodeSyntax.step

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -21,12 +21,11 @@ Description:
 Data-files:
   .stylish-haskell.yaml
 
-Executable stylish-haskell
-  Ghc-options:    -Wall
+Library
+  Exposed-modules: Language.Haskell.Stylish
   Hs-source-dirs: src
-  Main-is:        Main.hs
-
-  Other-modules:
+  Ghc-options:    -Wall
+  other-modules:
     Paths_stylish_haskell
     StylishHaskell
     StylishHaskell.Block
@@ -47,15 +46,24 @@ Executable stylish-haskell
     aeson            >= 0.6  && < 0.7,
     base             >= 4    && < 5,
     bytestring       >= 0.9  && < 0.10,
-    cmdargs          >= 0.9  && < 0.11,
     containers       >= 0.3  && < 0.6,
     directory        >= 1.1  && < 1.2,
     filepath         >= 1.1  && < 1.4,
     haskell-src-exts >= 1.13 && < 1.14,
     mtl              >= 2.0  && < 2.2,
-    strict           >= 0.3  && < 0.4,
     syb              >= 0.3  && < 0.4,
     yaml             >= 0.7  && < 0.9
+
+Executable stylish-haskell
+  Ghc-options:    -Wall
+  Hs-source-dirs: app
+  Main-is:        Main.hs
+
+  Build-depends:
+    base             >= 4    && < 5,
+    cmdargs          >= 0.9  && < 0.11,
+    strict           >= 0.3  && < 0.4,
+    stylish-haskell
 
 Test-suite stylish-haskell-tests
   Ghc-options:    -Wall


### PR DESCRIPTION
This is a very simple patch which exposes a library for using stylish-haskell. I've made as few changes to the core as possible. I have no need for this particular API, so if there's something else you'd rather use, I have no objections. I'd just like to be able to interact with stylish without going through an external process.
