### PR TITLE
Don't add paddding for non-existent qualified imports.

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -22,6 +22,9 @@ steps:
       # - global: Align the import names and import list throughout the entire
       #   file.
       #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
       # - group: Only align the imports per group (a group is formed by adjacent
       #   import lines).
       #

--- a/src/Language/Haskell/Stylish/Config.hs
+++ b/src/Language/Haskell/Stylish/Config.hs
@@ -159,6 +159,7 @@ parseImports config o = Imports.step
   where
     aligns =
         [ ("global", Imports.Global)
+        , ("file",   Imports.File)
         , ("group",  Imports.Group)
         , ("none",   Imports.None)
         ]

--- a/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
@@ -23,6 +23,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Imports.Tests"
     , testCase "case 03" case03
     , testCase "case 04" case04
     , testCase "case 05" case05
+    , testCase "case 06" case06
     ]
 
 
@@ -121,3 +122,16 @@ case05 = input' @=? testStep (step 80 Group) input'
   where
     input' = "import Distribution.PackageDescription.Configuration " ++
         "(finalizePackageDescription)\n"
+
+--------------------------------------------------------------------------------
+case06 :: Assertion
+case06 = expected @=? testStep (step 80 File) input'
+  where
+    input' =
+        "import Data.Aeson.Types (object, typeMismatch, FromJSON(..)," ++
+        "ToJSON(..), Value(..), parseEither, (.!=), (.:), (.:?), (.=))"
+
+    expected = unlines
+        [ "import Data.Aeson.Types (FromJSON (..), ToJSON (..), Value (..), object,"
+        , "                         parseEither, typeMismatch, (.!=), (.:), (.:?), (.=))"
+        ]


### PR DESCRIPTION
Before this change

```
import A
import B
```

was transformed to

```
import           A
import           B
```

by default even if there were no qualified imports in the whole file.
