### PR TITLE
Search for the config file in the project root.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -78,11 +78,13 @@ The tool is customizable to some extent. It tries to find a config file in the
 following order:
 
 1. A file passed to the tool using the `-c/--config` argument
-2. `.stylish-haskell.yaml` in the current directory (useful for per-project
+2. `.stylish-haskell.yaml` in the current directory (useful for per-directory
    settings)
-3. `.stylish-haskell.yaml` in your home directory (useful for user-wide
+3. `.stylish-haskell.yaml` in the nearest ancestor directory (useful for
+   per-project settings)
+4. `.stylish-haskell.yaml` in your home directory (useful for user-wide
    settings)
-4. The default settings.
+5. The default settings.
 
 Use `stylish-haskell --defaults > .stylish-haskell.yaml` to dump a
 well-documented default configuration to a file, this way you can get started


### PR DESCRIPTION
Project root is defined as the nearest ancestor directory that contains a .cabal
file (the same logic that Git uses for finding the .git directory). Project root
is searched after the current directory, but before the home directory.
