### PR TITLE
Added new pragma style `line'

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -41,6 +41,7 @@ steps:
       #
       # - compact: A more compact style.
       #
+      # - compact_line: Similar to compact, but wrap each line by `{-#LANGUAGE #-}'.
       # Default: vertical.
       style: vertical
 

--- a/src/Language/Haskell/Stylish/Config.hs
+++ b/src/Language/Haskell/Stylish/Config.hs
@@ -178,9 +178,9 @@ parseLanguagePragmas config o = LanguagePragmas.step
     <*> o A..:? "remove_redundant" A..!= True
   where
     styles =
-        [ ("vertical", LanguagePragmas.Vertical)
-        , ("compact",  LanguagePragmas.Compact)
-        , ("line",     LanguagePragmas.Line)]
+        [ ("vertical",     LanguagePragmas.Vertical)
+        , ("compact",      LanguagePragmas.Compact)
+        , ("compact_line", LanguagePragmas.CompactLine)]
 
 
 --------------------------------------------------------------------------------

--- a/tests/Language/Haskell/Stylish/Step/LanguagePragmas/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/LanguagePragmas/Tests.hs
@@ -5,14 +5,14 @@ module Language.Haskell.Stylish.Step.LanguagePragmas.Tests
 
 
 --------------------------------------------------------------------------------
-import           Test.Framework                      (Test, testGroup)
-import           Test.Framework.Providers.HUnit      (testCase)
-import           Test.HUnit                          (Assertion, (@=?))
+import Test.Framework                 (Test, testGroup)
+import Test.Framework.Providers.HUnit (testCase)
+import Test.HUnit                     (Assertion, (@=?))
 
 
 --------------------------------------------------------------------------------
-import           Language.Haskell.Stylish.Step.LanguagePragmas
-import           Language.Haskell.Stylish.Tests.Util
+import Language.Haskell.Stylish.Step.LanguagePragmas
+import Language.Haskell.Stylish.Tests.Util
 
 
 --------------------------------------------------------------------------------
@@ -112,4 +112,18 @@ case05 = expected @=? testStep (step 80 Vertical False) input
         , "#if __GLASGOW_HASKELL__ >= 702"
         , "{-# LANGUAGE Trustworthy #-}"
         , "#endif"
+        ]
+
+case06 :: Assertion
+case06 = expected @=? testStep (step 80 CompactLine True) input
+  where
+    input = unlines
+        [ "{-# LANGUAGE TypeOperators, StandaloneDeriving, DeriveDataTypeable,"
+        , "    TemplateHaskell #-}"
+        , "{-# LANGUAGE TemplateHaskell, ViewPatterns #-}"
+        ]
+    expected = unlines
+        [ "{-# LANGUAGE DeriveDataTypeable, StandaloneDeriving, " ++
+          "TemplateHaskell #-}"
+        , "{-# LANGUAGE TypeOperators, ViewPatterns                             #-}"
         ]


### PR DESCRIPTION
I added new style for language pragma called `line` (there could be better name, I think).

It's like `compact` style, but it adds `{-# LANGUAGE` to each line like below:

``` haskell
{-# LANGUAGE ConstraintKinds, DataKinds, FlexibleContexts, GADTs             #-}
{-# LANGUAGE MultiParamTypeClasses, NoImplicitPrelude, ParallelListComp      #-}
{-# LANGUAGE RankNTypes, ScopedTypeVariables, TemplateHaskell, TypeOperators #-}
```
