### PR TITLE
Updated mtl dependency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,2 @@
-- 0.5.10.0
-    * Bump `haskell-src-exts` dependency to 1.15
-    * Fix test which was not run before
+- 0.5.10.1
+    * Bump `mtl` dependency to 2.3

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -1,5 +1,5 @@
 Name:          stylish-haskell
-Version:       0.5.10.0
+Version:       0.5.10.1
 Synopsis:      Haskell code prettifier
 Homepage:      https://github.com/jaspervdj/stylish-haskell
 License:       BSD3
@@ -53,7 +53,7 @@ Library
     directory        >= 1.1  && < 1.3,
     filepath         >= 1.1  && < 1.4,
     haskell-src-exts >= 1.14 && < 1.16,
-    mtl              >= 2.0  && < 2.2,
+    mtl              >= 2.0  && < 2.3,
     syb              >= 0.3  && < 0.5,
     yaml             >= 0.7  && < 0.9
 
@@ -74,7 +74,7 @@ Executable stylish-haskell
     directory        >= 1.1  && < 1.3,
     filepath         >= 1.1  && < 1.4,
     haskell-src-exts >= 1.14 && < 1.16,
-    mtl              >= 2.0  && < 2.2,
+    mtl              >= 2.0  && < 2.3,
     syb              >= 0.3  && < 0.5,
     yaml             >= 0.7  && < 0.9
 
@@ -107,7 +107,7 @@ Test-suite stylish-haskell-tests
     directory        >= 1.1  && < 1.3,
     filepath         >= 1.1  && < 1.4,
     haskell-src-exts >= 1.14 && < 1.16,
-    mtl              >= 2.0  && < 2.2,
+    mtl              >= 2.0  && < 2.3,
     syb              >= 0.3  && < 0.5,
     yaml             >= 0.7  && < 0.9
 


### PR DESCRIPTION
`stylish-haskell` compiles without change using `mtl-2.2.0.1`, so I updated the dependencies in the cabal file.
