### PR TITLE
Fix for haskell-src-exts 0.16 release

### DIFF
--- a/src/Language/Haskell/Stylish/Step/Imports.hs
+++ b/src/Language/Haskell/Stylish/Step/Imports.hs
@@ -59,7 +59,7 @@ compareImportSpecs :: H.ImportSpec l -> H.ImportSpec l -> Ordering
 compareImportSpecs = comparing key
   where
     key :: H.ImportSpec l -> (Int, Int, String)
-    key (H.IVar _ x)         = let n = nameToString x in (1, operator n, n)
+    key (H.IVar _ _ x)       = let n = nameToString x in (1, operator n, n)
     key (H.IAbs _ x)         = (0, 0, nameToString x)
     key (H.IThingAll _ x)    = (0, 0, nameToString x)
     key (H.IThingWith _ x _) = (0, 0, nameToString x)

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -52,7 +52,7 @@ Library
     containers       >= 0.3  && < 0.6,
     directory        >= 1.1  && < 1.3,
     filepath         >= 1.1  && < 1.4,
-    haskell-src-exts >= 1.14 && < 1.16,
+    haskell-src-exts == 1.16.*,
     mtl              >= 2.0  && < 2.3,
     syb              >= 0.3  && < 0.5,
     yaml             >= 0.7  && < 0.9
@@ -73,7 +73,7 @@ Executable stylish-haskell
     containers       >= 0.3  && < 0.6,
     directory        >= 1.1  && < 1.3,
     filepath         >= 1.1  && < 1.4,
-    haskell-src-exts >= 1.14 && < 1.16,
+    haskell-src-exts == 1.16.*,
     mtl              >= 2.0  && < 2.3,
     syb              >= 0.3  && < 0.5,
     yaml             >= 0.7  && < 0.9
@@ -106,7 +106,7 @@ Test-suite stylish-haskell-tests
     containers       >= 0.3  && < 0.6,
     directory        >= 1.1  && < 1.3,
     filepath         >= 1.1  && < 1.4,
-    haskell-src-exts >= 1.14 && < 1.16,
+    haskell-src-exts == 1.16.*,
     mtl              >= 2.0  && < 2.3,
     syb              >= 0.3  && < 0.5,
     yaml             >= 0.7  && < 0.9


### PR DESCRIPTION
Unfortunately makes it incompatible with earlier haskell-src-exts package versions, unless you want to use CPP
