### PR TITLE
Move CHANGELOG entry for 0.5.9.0 from README

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,3 +51,6 @@
 - 0.5.10.0
     * Bump `haskell-src-exts` dependency to 1.15
     * Fix test which was not run before
+
+- `0.5.9.0`
+    * Add `compact_line` setting for Language Pragma styling

--- a/README.markdown
+++ b/README.markdown
@@ -136,9 +136,3 @@ Contributors:
 - Leonid Onokhov
 - Michael Snoyman
 - Mikhail Glushenkov
-
-Changelog
----------
-
-- `0.5.9.0`
-    * Add `compact_line` setting for Language Pragma styling


### PR DESCRIPTION
Move the entry for 0.5.9.0 to where it should be.  Thanks.