### PR TITLE
utf8 encoding support (code with Unicode operators)

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,17 +1,21 @@
 --------------------------------------------------------------------------------
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE OverloadedStrings  #-}
 module Main
     ( main
     ) where
 
 
 --------------------------------------------------------------------------------
-import           Control.Monad          (forM_)
-import           Data.List              (intercalate)
-import           Data.Version           (Version(..))
+import           Control.Monad              (forM_)
+import qualified Data.ByteString.Lazy.Char8 as B
+import           Data.List                  (intercalate)
+import qualified Data.Text.Lazy             as T
+import           Data.Text.Lazy.Encoding    (decodeUtf8)
+import           Data.Version               (Version (..))
 import           System.Console.CmdArgs
-import           System.IO              (hPutStrLn, stderr, withFile, hSetEncoding, IOMode(ReadMode), utf8)
-import           System.IO.Strict       (hGetContents)
+import           System.IO                  (hPutStrLn, hSetEncoding, stderr,
+                                             stdin, stdout, utf8)
 
 
 --------------------------------------------------------------------------------
@@ -43,7 +47,9 @@ stylishArgs = StylishArgs
 
 --------------------------------------------------------------------------------
 main :: IO ()
-main = cmdArgs stylishArgs >>= stylishHaskell
+main = do
+  mapM_ (`hSetEncoding` utf8) [stdin, stdout]
+  cmdArgs stylishArgs >>= stylishHaskell
 
 
 --------------------------------------------------------------------------------
@@ -83,8 +89,7 @@ file sa conf mfp = do
                 _ -> return ()
 
 readUTF8File :: FilePath -> IO String
-readUTF8File fp =
-     withFile fp ReadMode $ \h -> do
-        hSetEncoding h utf8
-        content <- hGetContents h
-        return content
+readUTF8File fp = do
+    content <- B.readFile fp
+    let utf = decodeUtf8 content
+    return (T.unpack utf)

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -70,6 +70,7 @@ Executable stylish-haskell
     aeson            >= 0.6  && < 0.12,
     base             >= 4.8  && < 5,
     bytestring       >= 0.9  && < 0.11,
+    text             >= 1.0  && < 1.3,
     containers       >= 0.3  && < 0.6,
     directory        >= 1.1  && < 1.3,
     filepath         >= 1.1  && < 1.5,


### PR DESCRIPTION
fixes: https://github.com/jaspervdj/stylish-haskell/issues/108#issuecomment-222673102
related: https://github.com/atom-haskell/ide-haskell-cabal/issues/11#issuecomment-222075876

actually seems like maybe something is wrong with line endings, not really sure
will try to get rid of unrelated changes later
