### PR TITLE
Add newline format option

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -144,7 +144,16 @@ steps:
 # to. Different steps take this into account. Default: 80.
 columns: 80
 
-# Newline format for output files
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
 newline: native
 
 # Sometimes, language extensions are specified in a cabal file or from the

--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -144,6 +144,9 @@ steps:
 # to. Different steps take this into account. Default: 80.
 columns: 80
 
+# Newline format for output files
+newline: native
+
 # Sometimes, language extensions are specified in a cabal file or from the
 # command line instead of using language pragmas in the file. stylish-haskell
 # needs to be aware of these, so it can parse the file correctly.

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -24,6 +24,8 @@ import           System.Directory
 import           System.FilePath                                  (joinPath,
                                                                    splitPath,
                                                                    (</>))
+import qualified System.IO                                        as IO (Newline (..),
+                                                                         nativeNewline)
 
 
 --------------------------------------------------------------------------------
@@ -47,6 +49,7 @@ data Config = Config
     { configSteps              :: [Step]
     , configColumns            :: Int
     , configLanguageExtensions :: [String]
+    , configNewline            :: IO.Newline
     }
 
 
@@ -115,11 +118,18 @@ parseConfig (A.Object o) = do
         <$> pure []
         <*> (o A..:? "columns"             A..!= 80)
         <*> (o A..:? "language_extensions" A..!= [])
+        <*> (o A..:? "newline"             >>= parseEnum newlines IO.nativeNewline)
 
     -- Then fill in the steps based on the partial config we already have
     stepValues <- o A..: "steps" :: A.Parser [A.Value]
     steps      <- mapM (parseSteps config) stepValues
     return config {configSteps = concat steps}
+  where
+    newlines =
+        [ ("native", IO.nativeNewline)
+        , ("lf",     IO.LF)
+        , ("crlf",   IO.CRLF)
+        ]
 parseConfig _            = mzero
 
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -123,7 +123,12 @@ file sa conf mfp = do
     write old new = case mfp of
                 Nothing -> putStr new
                 Just _    | not (saInPlace sa) -> putStr new
-                Just path | not (null new) && old /= new  -> writeFile path new
+                Just path | not (null new) && old /= new  ->
+                    IO.withFile path IO.WriteMode $ \h -> do
+                        let nl = configNewline conf
+                        let mode = IO.NewlineMode nl nl
+                        IO.hSetNewlineMode h mode
+                        IO.hPutStr h new
                 _ -> return ()
 
 readUTF8File :: FilePath -> IO String

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -121,15 +121,18 @@ file sa conf mfp = do
         Right ok  -> write contents $ unlines ok
   where
     write old new = case mfp of
-                Nothing -> putStr new
-                Just _    | not (saInPlace sa) -> putStr new
+                Nothing -> putStrNewline new
+                Just _    | not (saInPlace sa) -> putStrNewline new
                 Just path | not (null new) && old /= new  ->
                     IO.withFile path IO.WriteMode $ \h -> do
-                        let nl = configNewline conf
-                        let mode = IO.NewlineMode IO.nativeNewline nl
-                        IO.hSetNewlineMode h mode
+                        setNewlineMode h
                         IO.hPutStr h new
                 _ -> return ()
+    setNewlineMode h = do
+      let nl = configNewline conf
+      let mode = IO.NewlineMode IO.nativeNewline nl
+      IO.hSetNewlineMode h mode
+    putStrNewline txt = setNewlineMode IO.stdout >> putStr txt
 
 readUTF8File :: FilePath -> IO String
 readUTF8File fp =

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -126,7 +126,7 @@ file sa conf mfp = do
                 Just path | not (null new) && old /= new  ->
                     IO.withFile path IO.WriteMode $ \h -> do
                         let nl = configNewline conf
-                        let mode = IO.NewlineMode nl nl
+                        let mode = IO.NewlineMode IO.nativeNewline nl
                         IO.hSetNewlineMode h mode
                         IO.hPutStr h new
                 _ -> return ()


### PR DESCRIPTION
`writeFile` from Haskell uses native newline format, so on Windows all files end with CRLF after running `stylish-haskell`. This PR allows setting line endings (LF or CRLF) optionally. Default value (`native`) gives previous behavior.