### PR TITLE
Added reference to atom-beautify

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -127,7 +127,10 @@ Atom integration
 
 [ide-haskell] for Atom supports `stylish-haskell`.
 
+[atom-beautify] for Atom supports Haskell using `stylish-haskell`.
+
 [ide-haskell]: https://atom.io/packages/ide-haskell
+[atom-beautify]: Https://atom.io/packages/atom-beautify
 
 Credits
 -------


### PR DESCRIPTION
atom-beautify also supports Haskell via stylish-haskell, hence a reference here would probably be good.