### PR TITLE
Keep `safe` and `{-# SOURCE #-}` import annotations

### DIFF
--- a/lib/Language/Haskell/Stylish/Step/Imports.hs
+++ b/lib/Language/Haskell/Stylish/Step/Imports.hs
@@ -235,6 +235,8 @@ prettyImport columns Options{..} padQualified padName longest imp
 
     base' baseName importAs hasHiding' = unwords $ concat $ filter (not . null)
         [ ["import"]
+        , source
+        , safe
         , qualified
         , show <$> maybeToList (H.importPkg imp)
         , [baseName]
@@ -261,6 +263,14 @@ prettyImport columns Options{..} padQualified padName longest imp
         | H.importQualified imp = ["qualified"]
         | padQualified          = ["         "]
         | otherwise             = []
+
+    safe
+        | H.importSafe imp = ["safe"]
+        | otherwise        = []
+
+    source
+        | H.importSrc imp = ["{-# SOURCE #-}"]
+        | otherwise       = []
 
     mapSpecs f = case importSpecs of
         Nothing -> []     -- Import everything

--- a/lib/Language/Haskell/Stylish/Step/Imports.hs
+++ b/lib/Language/Haskell/Stylish/Step/Imports.hs
@@ -261,7 +261,12 @@ prettyImport columns Options{..} padQualified padName longest imp
 
     qualified
         | H.importQualified imp = ["qualified"]
-        | padQualified          = ["         "]
+        | padQualified          =
+              if H.importSrc imp
+                  then []
+                  else if H.importSafe imp
+                           then ["    "]
+                           else ["         "]
         | otherwise             = []
 
     safe

--- a/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
@@ -46,6 +46,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Imports.Tests"
     , testCase "case 19b" case19b
     , testCase "case 19d" case19c
     , testCase "case 19d" case19d
+    , testCase "case 20" case20
     ]
 
 
@@ -511,4 +512,20 @@ case19input = unlines
         , "import Prelude ()"
         , ""
         , "import Data.List (foldl', intercalate, intersperse)"
+        ]
+
+--------------------------------------------------------------------------------
+case20 :: Assertion
+case20 = expected
+    @=? testStep (step 80 defaultOptions) input'
+  where
+    expected = unlines
+        [ "import qualified Data.Map  as Map"
+        , "import           Data.Set  (empty)"
+        , "import {-# SOURCE #-} qualified Data.Text as T"
+        ]
+    input' = unlines
+        [ "import {-# SOURCE #-} qualified Data.Text as T"
+        , "import qualified   Data.Map as Map"
+        , "import Data.Set (empty)"
         ]

--- a/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
@@ -520,12 +520,14 @@ case20 = expected
     @=? testStep (step 80 defaultOptions) input'
   where
     expected = unlines
-        [ "import qualified Data.Map  as Map"
-        , "import           Data.Set  (empty)"
-        , "import {-# SOURCE #-} qualified Data.Text as T"
+        [ "import {-# SOURCE #-} Data.ByteString as BS"
+        , "import qualified Data.Map        as Map"
+        , "import           Data.Set        (empty)"
+        , "import {-# SOURCE #-} qualified Data.Text       as T"
         ]
     input' = unlines
-        [ "import {-# SOURCE #-} qualified Data.Text as T"
+        [ "import {-# SOURCE #-}    Data.ByteString as BS"
+        , "import {-# SOURCE #-} qualified Data.Text as T"
         , "import qualified   Data.Map as Map"
         , "import Data.Set (empty)"
         ]


### PR DESCRIPTION
Fixes #70 and #90. This only keeps the annotations but doesn't do any alignment or padding. IMHO still fine since they're so rarely used.