### PR TITLE
Don't leave #-} hanging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@
 - next
     * Remove `MagicHash` from whitelisted language extensions, since it was
       causing parsing errors
+    * Don't leave a `#-}` hanging on the next line when `language_pragmas`
+      is set to `compact` and the `#-}` doesn't fit into character limit
 
 - 0.7.1.0
     * Keep `safe` and `{-# SOURCE #-}` import annotations (by Moritz Drexl)

--- a/lib/Language/Haskell/Stylish/Step/LanguagePragmas.hs
+++ b/lib/Language/Haskell/Stylish/Step/LanguagePragmas.hs
@@ -56,7 +56,7 @@ verticalPragmas longest align pragmas' =
 --------------------------------------------------------------------------------
 compactPragmas :: Int -> [String] -> Lines
 compactPragmas columns pragmas' = wrap columns "{-# LANGUAGE" 13 $
-    map (++ ",") (init pragmas') ++ [last pragmas', "#-}"]
+    map (++ ",") (init pragmas') ++ [last pragmas' ++ " #-}"]
 
 
 --------------------------------------------------------------------------------

--- a/tests/Language/Haskell/Stylish/Step/LanguagePragmas/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/LanguagePragmas/Tests.hs
@@ -26,6 +26,8 @@ tests = testGroup "Language.Haskell.Stylish.Step.LanguagePragmas.Tests"
     , testCase "case 06" case06
     , testCase "case 07" case07
     , testCase "case 08" case08
+    , testCase "case 09" case09
+    , testCase "case 10" case10
     ]
 
 
@@ -166,4 +168,32 @@ case08 = expected @=? testStep (step 80 CompactLine False False) input
         [ "{-# LANGUAGE DeriveDataTypeable, StandaloneDeriving, " ++
           "TemplateHaskell #-}"
         , "{-# LANGUAGE TypeOperators, ViewPatterns #-}"
+        ]
+
+
+--------------------------------------------------------------------------------
+case09 :: Assertion
+case09 = expected @=? testStep (step 80 Compact True False) input
+  where
+    input = unlines
+        [ "{-# LANGUAGE DefaultSignatures, FlexibleInstances, LambdaCase, " ++
+          "TypeApplications"
+        , "             #-}"
+        ]
+    expected = unlines
+        [ "{-# LANGUAGE DefaultSignatures, FlexibleInstances, LambdaCase,"
+        , "             TypeApplications #-}"
+        ]
+
+--------------------------------------------------------------------------------
+case10 :: Assertion
+case10 = expected @=? testStep (step 80 Compact True False) input
+  where
+    input = unlines
+        [ "{-# LANGUAGE NondecreasingIndentation, ScopedTypeVariables,"
+        , "             TypeApplications #-}"
+        ]
+    expected = unlines
+        [ "{-# LANGUAGE NondecreasingIndentation, ScopedTypeVariables, " ++
+          "TypeApplications #-}"
         ]


### PR DESCRIPTION
See #154 for an example:

```
{-# LANGUAGE DefaultSignatures, FlexibleInstances, LambdaCase, TypeApplications
             #-}
```

This PR prevents the situation above by glueing `#-}` to the last pragma. In the case above, it leads to the following rendering:

```
{-# LANGUAGE DefaultSignatures, FlexibleInstances, LambdaCase,
             TypeApplications #-}
```

The PR doesn't affect cases when the whole line fits into the character limit.