### PR TITLE
Space surround

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -126,6 +126,22 @@ steps:
       # Default: true
       separate_lists: true
 
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
   # Language pragmas
   - language_pragmas:
       # We can generate different styles of language pragma lists.

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -190,7 +190,8 @@ parseImports config o = Imports.step
         <*> (o A..:? "empty_list_align"
             >>= parseEnum emptyListAligns (def Imports.emptyListAlign))
         <*> o A..:? "list_padding" A..!= (def Imports.listPadding)
-        <*> o A..:? "separate_lists" A..!= (def Imports.separateLists))
+        <*> o A..:? "separate_lists" A..!= (def Imports.separateLists)
+        <*> o A..:? "space_surround" A..!= (def Imports.spaceSurround))
   where
     def f = f Imports.defaultOptions
 

--- a/lib/Language/Haskell/Stylish/Step/Imports.hs
+++ b/lib/Language/Haskell/Stylish/Step/Imports.hs
@@ -289,14 +289,14 @@ prettyImport columns Options{..} padQualified padName longest imp
         NewLine    -> (paddedNoSpecBase :) . wrapRest columns listPadding'
         WithAlias  -> wrap columns paddedBase (inlineBaseLength + 1)
         -- Add 1 extra space to ensure same padding as in original code.
-        AfterAlias -> withTail (' ' :)
+        AfterAlias -> withTail ((' ' : maybeSpace) ++)
             . wrap columns paddedBase (afterAliasBaseLength + 1)
 
     inlineWithBreakWrap = paddedNoSpecBase : wrapRest columns listPadding'
         ( mapSpecs
         $ withInit (++ ",")
-        . withHead ("(" ++)
-        . withLast (++ ")"))
+        . withHead (("(" ++ maybeSpace) ++)
+        . withLast (++ (maybeSpace ++ ")")))
 
     inlineToMultilineWrap
         | length inlineWithBreakWrap > 2

--- a/lib/Language/Haskell/Stylish/Step/Imports.hs
+++ b/lib/Language/Haskell/Stylish/Step/Imports.hs
@@ -42,6 +42,7 @@ data Options = Options
     , emptyListAlign :: EmptyListAlign
     , listPadding    :: ListPadding
     , separateLists  :: Bool
+    , spaceSurround  :: Bool
     } deriving (Eq, Show)
 
 defaultOptions :: Options
@@ -52,6 +53,7 @@ defaultOptions = Options
     , emptyListAlign = Inherit
     , listPadding    = LPConstant 4
     , separateLists  = True
+    , spaceSurround  = False
     }
 
 data ListPadding
@@ -280,8 +282,8 @@ prettyImport columns Options{..} padQualified padName longest imp
     inlineWrap = inlineWrapper
         $ mapSpecs
         $ withInit (++ ",")
-        . withHead ("(" ++)
-        . withLast (++ ")")
+        . withHead (("(" ++ maybeSpace) ++)
+        . withLast (++ (maybeSpace ++ ")"))
 
     inlineWrapper = case listAlign of
         NewLine    -> (paddedNoSpecBase :) . wrapRest columns listPadding'
@@ -369,6 +371,10 @@ prettyImport columns Options{..} padQualified padName longest imp
         Nothing -> []     -- Import everything
         Just [] -> ["()"] -- Instance only imports
         Just is -> f $ map (prettyImportSpec separateLists) is
+
+    maybeSpace = case spaceSurround of
+        True -> " "
+        False -> ""
 
 
 --------------------------------------------------------------------------------

--- a/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
@@ -49,6 +49,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Imports.Tests"
     , testCase "case 20" case20
     , testCase "case 21" case21
     , testCase "case 22" case22
+    , testCase "case 23" case23
     ]
 
 
@@ -188,7 +189,7 @@ case07 = expected @=? testStep (step 80 $ fromImportAlign File) input'
 --------------------------------------------------------------------------------
 case08 :: Assertion
 case08 = expected
-    @=? testStep (step 80 $ Options Global WithAlias Inline Inherit (LPConstant 4) True) input
+    @=? testStep (step 80 $ Options Global WithAlias Inline Inherit (LPConstant 4) True False) input
   where
     expected = unlines
         [ "module Herp where"
@@ -211,7 +212,7 @@ case08 = expected
 --------------------------------------------------------------------------------
 case09 :: Assertion
 case09 = expected
-    @=? testStep (step 80 $ Options Global WithAlias Multiline Inherit (LPConstant 4) True) input
+    @=? testStep (step 80 $ Options Global WithAlias Multiline Inherit (LPConstant 4) True False) input
   where
     expected = unlines
         [ "module Herp where"
@@ -245,7 +246,7 @@ case09 = expected
 --------------------------------------------------------------------------------
 case10 :: Assertion
 case10 = expected
-    @=? testStep (step 40 $ Options Group WithAlias Multiline Inherit (LPConstant 4) True) input
+    @=? testStep (step 40 $ Options Group WithAlias Multiline Inherit (LPConstant 4) True False) input
   where
     expected = unlines
         [ "module Herp where"
@@ -284,7 +285,7 @@ case10 = expected
 --------------------------------------------------------------------------------
 case11 :: Assertion
 case11 = expected
-    @=? testStep (step 80 $ Options Group NewLine Inline Inherit (LPConstant 4) True) input
+    @=? testStep (step 80 $ Options Group NewLine Inline Inherit (LPConstant 4) True False) input
   where
     expected = unlines
         [ "module Herp where"
@@ -312,7 +313,7 @@ case11 = expected
 --------------------------------------------------------------------------------
 case12 :: Assertion
 case12 = expected
-    @=? testStep (step 80 $ Options Group NewLine Inline Inherit (LPConstant 2) True) input'
+    @=? testStep (step 80 $ Options Group NewLine Inline Inherit (LPConstant 2) True False) input'
   where
     input' = unlines
         [ "import Data.List (map)"
@@ -327,7 +328,7 @@ case12 = expected
 --------------------------------------------------------------------------------
 case13 :: Assertion
 case13 = expected
-    @=? testStep (step 80 $ Options None WithAlias InlineWithBreak Inherit (LPConstant 4) True) input'
+    @=? testStep (step 80 $ Options None WithAlias InlineWithBreak Inherit (LPConstant 4) True False) input'
   where
     input' = unlines
         [ "import qualified Data.List as List (concat, foldl, foldr, head, init,"
@@ -345,7 +346,7 @@ case13 = expected
 case14 :: Assertion
 case14 = expected
     @=? testStep
-      (step 80 $ Options None WithAlias InlineWithBreak Inherit (LPConstant 10) True) expected
+      (step 80 $ Options None WithAlias InlineWithBreak Inherit (LPConstant 10) True False) expected
   where
     expected = unlines
         [ "import qualified Data.List as List (concat, map, null, reverse, tail, (++))"
@@ -355,7 +356,7 @@ case14 = expected
 --------------------------------------------------------------------------------
 case15 :: Assertion
 case15 = expected
-    @=? testStep (step 80 $ Options None AfterAlias Multiline Inherit (LPConstant 4) True) input'
+    @=? testStep (step 80 $ Options None AfterAlias Multiline Inherit (LPConstant 4) True False) input'
   where
     expected = unlines
         [ "import Data.Acid (AcidState)"
@@ -381,7 +382,7 @@ case15 = expected
 --------------------------------------------------------------------------------
 case16 :: Assertion
 case16 = expected
-    @=? testStep (step 80 $ Options None AfterAlias Multiline Inherit (LPConstant 4) False) input'
+    @=? testStep (step 80 $ Options None AfterAlias Multiline Inherit (LPConstant 4) False False) input'
   where
     expected = unlines
         [ "import Data.Acid (AcidState)"
@@ -405,7 +406,7 @@ case16 = expected
 --------------------------------------------------------------------------------
 case17 :: Assertion
 case17 = expected
-    @=? testStep (step 80 $ Options None AfterAlias Multiline Inherit (LPConstant 4) True) input'
+    @=? testStep (step 80 $ Options None AfterAlias Multiline Inherit (LPConstant 4) True False) input'
   where
     expected = unlines
         [ "import Control.Applicative (Applicative (pure, (<*>)))"
@@ -423,7 +424,7 @@ case17 = expected
 --------------------------------------------------------------------------------
 case18 :: Assertion
 case18 = expected @=? testStep
-    (step 40 $ Options None AfterAlias InlineToMultiline Inherit (LPConstant 4) True) input'
+    (step 40 $ Options None AfterAlias InlineToMultiline Inherit (LPConstant 4) True False) input'
   where
     expected = unlines
            ----------------------------------------
@@ -450,7 +451,7 @@ case18 = expected @=? testStep
 --------------------------------------------------------------------------------
 case19 :: Assertion
 case19 = expected @=? testStep
-    (step 40 $ Options Global NewLine InlineWithBreak RightAfter (LPConstant 17) True) case19input
+    (step 40 $ Options Global NewLine InlineWithBreak RightAfter (LPConstant 17) True False) case19input
   where
     expected = unlines
            ----------------------------------------
@@ -465,7 +466,7 @@ case19 = expected @=? testStep
 
 case19b :: Assertion
 case19b = expected @=? testStep
-    (step 40 $ Options File NewLine InlineWithBreak RightAfter (LPConstant 17) True) case19input
+    (step 40 $ Options File NewLine InlineWithBreak RightAfter (LPConstant 17) True False) case19input
   where
     expected = unlines
            ----------------------------------------
@@ -480,7 +481,7 @@ case19b = expected @=? testStep
 
 case19c :: Assertion
 case19c = expected @=? testStep
-    (step 40 $ Options File NewLine InlineWithBreak RightAfter LPModuleName True) case19input
+    (step 40 $ Options File NewLine InlineWithBreak RightAfter LPModuleName True False) case19input
   where
     expected = unlines
            ----------------------------------------
@@ -495,7 +496,7 @@ case19c = expected @=? testStep
 
 case19d :: Assertion
 case19d = expected @=? testStep
-    (step 40 $ Options Global NewLine InlineWithBreak RightAfter LPModuleName True) case19input
+    (step 40 $ Options Global NewLine InlineWithBreak RightAfter LPModuleName True False) case19input
   where
     expected = unlines
            ----------------------------------------
@@ -588,4 +589,27 @@ case22 = expected
         -- but doesn't fit when "foo" is included into the calculation
         , "import \"foo\" B (someLongName, someLongerName, " ++
           "theLongestNameYet, shortName)"
+        ]
+
+--------------------------------------------------------------------------------
+case23 :: Assertion
+case23 = expected
+    @=? testStep (step 80 $ Options None AfterAlias Multiline Inherit (LPConstant 4) True True) input'
+  where
+    expected = unlines
+        [ "import Data.Acid ( AcidState )"
+        , "import Data.Default.Class ( Default (def) )"
+        , ""
+        , "import Data.Monoid ( (<>) )"
+        , ""
+        , "import Data.Foo ( Foo, Goo )"
+        ]
+
+    input' = unlines
+        [ "import Data.Acid (AcidState)"
+        , "import Data.Default.Class (Default(def))"
+        , ""
+        , "import Data.Monoid ((<>) )"
+        , ""
+        , "import Data.Foo (Foo, Goo)"
         ]

--- a/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
@@ -50,6 +50,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Imports.Tests"
     , testCase "case 21" case21
     , testCase "case 22" case22
     , testCase "case 23" case23
+    , testCase "case 24" case24
     ]
 
 
@@ -594,7 +595,7 @@ case22 = expected
 --------------------------------------------------------------------------------
 case23 :: Assertion
 case23 = expected
-    @=? testStep (step 80 $ Options None AfterAlias Multiline Inherit (LPConstant 4) True True) input'
+    @=? testStep (step 40 $ Options None AfterAlias Inline Inherit (LPConstant 4) True True) input'
   where
     expected = unlines
         [ "import Data.Acid ( AcidState )"
@@ -602,7 +603,8 @@ case23 = expected
         , ""
         , "import Data.Monoid ( (<>) )"
         , ""
-        , "import Data.Foo ( Foo, Goo )"
+        , "import Data.ALongName.Foo ( Boo, Foo,"
+        , "                            Goo )"
         ]
 
     input' = unlines
@@ -611,5 +613,28 @@ case23 = expected
         , ""
         , "import Data.Monoid ((<>) )"
         , ""
-        , "import Data.Foo (Foo, Goo)"
+        , "import Data.ALongName.Foo (Foo, Goo, Boo)"
+        ]
+
+--------------------------------------------------------------------------------
+case24 :: Assertion
+case24 = expected
+    @=? testStep (step 40 $ Options None AfterAlias InlineWithBreak Inherit (LPConstant 4) True True) input'
+  where
+    expected = unlines
+        [ "import Data.Acid ( AcidState )"
+        , "import Data.Default.Class"
+        , "    ( Default (def) )"
+        , ""
+        , "import Data.ALongName.Foo"
+        , "    ( BooReallyLong, FooReallyLong,"
+        , "    GooReallyLong )"
+        ]
+
+    input' = unlines
+        [ "import Data.Acid (AcidState)"
+        , "import Data.Default.Class (Default(def))"
+        , ""
+        , "import Data.ALongName.Foo (FooReallyLong, " ++
+          "GooReallyLong, BooReallyLong)"
         ]


### PR DESCRIPTION
eg:

    import Data.Foo ( foo )

instead of 

    import Data.Foo (foo)