### PR TITLE
Remove shebang lines

### DIFF
--- a/lib/Language/Haskell/Stylish/Parse.hs
+++ b/lib/Language/Haskell/Stylish/Parse.hs
@@ -44,11 +44,11 @@ unCpp = unlines . go False . lines
 
 
 --------------------------------------------------------------------------------
--- | Remove shebang from the first line
+-- | Remove shebang lines
 unShebang :: String -> String
-unShebang str
-    | "#!" `isPrefixOf` str = unlines $ ("" :) $ drop 1 $ lines str
-    | otherwise             = str
+unShebang str =
+    let (shebangs, other) = break (not . ("#!" `isPrefixOf`)) (lines str) in
+    unlines $ map (const "") shebangs ++ other
 
 
 --------------------------------------------------------------------------------

--- a/tests/Language/Haskell/Stylish/Parse/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Parse/Tests.hs
@@ -22,6 +22,7 @@ tests = testGroup "Language.Haskell.Stylish.Parse"
     , testCase "Haskell2010 extension"       testHaskell2010
     , testCase "Shebang"                     testShebang
     , testCase "ShebangExt"                  testShebangExt
+    , testCase "ShebangDouble"               testShebangDouble
     , testCase "GADTs extension"             testGADTs
     , testCase "KindSignatures extension"    testKindSignatures
     , testCase "StandalonDeriving extension" testStandaloneDeriving
@@ -79,6 +80,16 @@ testHaskell2010 = assert $ isRight $ parseModule [] Nothing $ unlines
 testShebang :: Assertion
 testShebang = assert $ isRight $ parseModule [] Nothing $ unlines
     [ "#!runhaskell"
+    , "module Main where"
+    , "main = return ()"
+    ]
+
+--------------------------------------------------------------------------------
+
+testShebangDouble :: Assertion
+testShebangDouble = assert $ isRight $ parseModule [] Nothing $ unlines
+    [ "#!nix-shell"
+    , "#!nix-shell -i runhaskell -p haskellPackages.ghc"
     , "module Main where"
     , "main = return ()"
     ]


### PR DESCRIPTION
`nix-shell` has the ability to be used as an interpreter since [version 1.9](https://nixos.org/releases/nix/nix-1.9/manual/#ssec-relnotes-1.9), and the release notes provide an example using Haskell. GHC supports this without any issues, but stylish-haskell only strips the first shebang line and then fails because it cannot parse the file. This provides the ability to strip up to the first two shebang lines.