### PR TITLE
Repsect page breaks alone in a line

### DIFF
--- a/lib/Language/Haskell/Stylish/Step/TrailingWhitespace.hs
+++ b/lib/Language/Haskell/Stylish/Step/TrailingWhitespace.hs
@@ -19,4 +19,9 @@ dropTrailingWhitespace = reverse . dropWhile isSpace . reverse
 
 --------------------------------------------------------------------------------
 step :: Step
-step = makeStep "TrailingWhitespace" $ \ls _ -> map dropTrailingWhitespace ls
+step = makeStep "TrailingWhitespace" $ \ls _ -> map dropTrailingWhitespace' ls
+  where
+    dropTrailingWhitespace' l = case l of
+      -- Preserve page breaks
+      "\12" -> l
+      _     -> dropTrailingWhitespace l

--- a/tests/Language/Haskell/Stylish/Step/TrailingWhitespace/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/TrailingWhitespace/Tests.hs
@@ -28,12 +28,16 @@ case01 = expected @=? testStep step input
   where
     input = unlines
         [ "module Main where"
-        , " "
+        , " \t"
         , "data Foo = Bar | Qux\t "
+        , "\12"    -- page break
+        , "   \12" -- malformed page break
         ]
 
     expected = unlines
         [ "module Main where"
         , ""
         , "data Foo = Bar | Qux"
+        , "\12" -- page break
+        , ""
         ]


### PR DESCRIPTION
Page breaks are an old but effective way of bookmarking a file. They
usually are single character lines. Stylish removes them as whitespace
characters, and they are from the compiler's point of view but not
from an editor's perspective.

Resolves #208 