### PR TITLE
README: Mention vim-autoformat

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -124,6 +124,16 @@ Or you can define `formatprg`
 
 and then use `gq`.
 
+Alternatively, [vim-autoformat] supports stylish-haskell. To have it automatically reformat the files on save, add to your vimrc:
+
+```vim
+autocmd BufWrite *.hs :Autoformat
+" Don't automatically indent on save, since vim's autoindent for haskell is buggy
+autocmd FileType haskell let b:autoformat_autoindent=0
+```
+
+[vim-autoformat]: https://github.com/Chiel92/vim-autoformat
+
 There is also the [vim-stylish-haskell] plugin, which runs stylish-haskell
 automatically when you save a Haskell file.
 


### PR DESCRIPTION
A more generic and better-behaving plugin than `vim-stylish-haskell`, so worth mentioning as an alternative