### PR TITLE
Implemented a new import style "semicolons".

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -36,6 +36,10 @@ steps:
       # - group: Only align the imports per group (a group is formed by adjacent
       #   import lines).
       #
+      # - semicolons: Like group, but indents non-qualified imports instead of
+      #   having a column for "qualified".  It uses semicolons to keep the
+      #   syntax legal.
+      #
       # - none: Do not perform any alignment.
       #
       # Default: global.

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -202,10 +202,12 @@ parseImports config o = Imports.step
     def f = f Imports.defaultOptions
 
     aligns =
-        [ ("global", Imports.Global)
-        , ("file",   Imports.File)
-        , ("group",  Imports.Group)
-        , ("none",   Imports.None)
+        [ ("global",          Imports.Global)
+        , ("file",            Imports.File)
+        , ("group",           Imports.Group)
+        , ("semicolons",      Imports.Semicolons)
+        , ("semicolons_none", Imports.SemicolonsNone)
+        , ("none",            Imports.None)
         ]
 
     listAligns =


### PR DESCRIPTION
With this style of formatting the import list, multiple imports
of the same library are indented as a single import stanza.  For,
example,

```
import qualified Data.Map as Map
         ;import Data.Map (Map)
````

A semicolon is prepended so that the compiler treats the indented
line as a top-level declaration.