### PR TITLE
Update bounds to support lts-13.0

### DIFF
--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -22,7 +22,8 @@ import           Data.List                                        (inits,
 import           Data.Map                                         (Map)
 import qualified Data.Map                                         as M
 import           Data.Maybe                                       (fromMaybe)
-import           Data.Yaml                                        (decodeEither)
+import           Data.Yaml                                        (decodeEither',
+                                                                   prettyPrintParseException)
 import           System.Directory
 import           System.FilePath                                  (joinPath,
                                                                    splitPath,
@@ -103,9 +104,9 @@ loadConfig verbose userSpecified = do
     mbFp <- configFilePath verbose userSpecified
     verbose $ "Loading configuration at " ++ fromMaybe "<embedded>" mbFp
     bytes <- maybe (return defaultConfigBytes) B.readFile mbFp
-    case decodeEither bytes of
+    case decodeEither' bytes of
         Left err     -> error $
-            "Language.Haskell.Stylish.Config.loadConfig: " ++ err
+            "Language.Haskell.Stylish.Config.loadConfig: " ++ prettyPrintParseException err
         Right config -> return config
 
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-11.5
-extra-deps:
-- 'aeson-1.3.1.0'
+resolver: lts-13.0

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -49,7 +49,7 @@ Library
     Paths_stylish_haskell
 
   Build-depends:
-    aeson            >= 0.6    && < 1.4,
+    aeson            >= 0.6    && < 1.5,
     base             >= 4.8    && < 5,
     bytestring       >= 0.9    && < 0.11,
     containers       >= 0.3    && < 0.7,
@@ -60,7 +60,7 @@ Library
     mtl              >= 2.0    && < 2.3,
     semigroups       >= 0.18   && < 0.19,
     syb              >= 0.3    && < 0.8,
-    yaml             >= 0.7    && < 0.10
+    yaml             >= 0.8.11 && < 0.12
 
 Executable stylish-haskell
   Ghc-options:    -Wall
@@ -72,7 +72,7 @@ Executable stylish-haskell
     strict               >= 0.3  && < 0.4,
     optparse-applicative >= 0.12 && < 0.15,
     -- Copied from regular dependencies...
-    aeson            >= 0.6    && < 1.4,
+    aeson            >= 0.6    && < 1.5,
     base             >= 4.8    && < 5,
     bytestring       >= 0.9    && < 0.11,
     containers       >= 0.3    && < 0.7,
@@ -82,7 +82,7 @@ Executable stylish-haskell
     haskell-src-exts >= 1.18   && < 1.21,
     mtl              >= 2.0    && < 2.3,
     syb              >= 0.3    && < 0.8,
-    yaml             >= 0.7    && < 0.10
+    yaml             >= 0.8.11 && < 0.12
 
 Test-suite stylish-haskell-tests
   Ghc-options:    -Wall
@@ -121,7 +121,7 @@ Test-suite stylish-haskell-tests
     test-framework       >= 0.4 && < 0.9,
     test-framework-hunit >= 0.2 && < 0.4,
     -- Copied from regular dependencies...
-    aeson            >= 0.6    && < 1.4,
+    aeson            >= 0.6    && < 1.5,
     base             >= 4.8    && < 5,
     bytestring       >= 0.9    && < 0.11,
     containers       >= 0.3    && < 0.7,
@@ -131,7 +131,7 @@ Test-suite stylish-haskell-tests
     haskell-src-exts >= 1.18   && < 1.21,
     mtl              >= 2.0    && < 2.3,
     syb              >= 0.3    && < 0.8,
-    yaml             >= 0.7    && < 0.10
+    yaml             >= 0.8.11 && < 0.12
 
 Source-repository head
   Type:     git


### PR DESCRIPTION
Bumped up the lower bound from `yaml` in order to avoid using `decodeEither`, which is now deprecated. `yaml-0.8.11` was released in [April 2015](https://github.com/snoyberg/yaml/releases/tag/yaml%2F0.8.11), so I don't see why anyone would have a problem upgrading that.