### PR TITLE
Update to Stack LTS 14.4

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.19
+resolver: lts-14.4
 
 packages:
   - '.'


### PR DESCRIPTION
In this new snapshot we have among other things a more recent version of `haskell-src-exts` which fixes a few of the parsing issues `stylish-haskell` has.

It definitely solves #210 but might also solve other issues like the ones to do with DerivingVia parsing.