### PR TITLE
Add support for GHC 8.8.1

### DIFF
--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -70,7 +70,7 @@ Executable stylish-haskell
   Build-depends:
     stylish-haskell,
     strict               >= 0.3  && < 0.4,
-    optparse-applicative >= 0.12 && < 0.15,
+    optparse-applicative >= 0.12 && < 0.16,
     -- Copied from regular dependencies...
     aeson            >= 0.6    && < 1.5,
     base             >= 4.8    && < 5,


### PR DESCRIPTION
optparse-applicative has upgraded to GHC 8.8.1 in the 0.15 version.