### PR TITLE
Bump haskell-src-exts to 1.23

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
-resolver: lts-14.13
+resolver: lts-14.20
 packages:
 - '.'
 
 extra-deps:
 - 'Cabal-3.0.0.0'
-- 'haskell-src-exts-1.22.0'
+- 'haskell-src-exts-1.23.0'

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,15 +12,15 @@ packages:
   original:
     hackage: Cabal-3.0.0.0
 - completed:
-    hackage: haskell-src-exts-1.22.0@sha256:f558923a9c8f57402c33a8cc871b934027a5c65414404c87239f6cbd7357d54e,4541
+    hackage: haskell-src-exts-1.23.0@sha256:1bb9f7e97d569e56973133cb075fdcc1bfd11f90d94b035b5cf44814bb39a73d,4541
     pantry-tree:
-      size: 96940
-      sha256: 597b6f48bd409a4d0da013c4e356945c42e0d098966035d3aa68cd4a3ccd66c9
+      size: 97804
+      sha256: 8e5bc885533431db9bf75e9609f6b80b56ab0c289a903d701f8628e78322afd0
   original:
-    hackage: haskell-src-exts-1.22.0
+    hackage: haskell-src-exts-1.23.0
 snapshots:
 - completed:
-    size: 525876
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/13.yaml
-    sha256: 4a0e79eb194c937cc2a1852ff84d983c63ac348dc6bad5f38d20cab697036eef
-  original: lts-14.13
+    size: 524154
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/20.yaml
+    sha256: 2f5099f69ddb6abfe64400fe1e6a604e8e628f55e6837211cd70a81eb0a8fa4d
+  original: lts-14.20

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -59,7 +59,7 @@ Library
     directory        >= 1.2.3  && < 1.4,
     filepath         >= 1.1    && < 1.5,
     file-embed       >= 0.0.10 && < 0.1,
-    haskell-src-exts >= 1.18   && < 1.23,
+    haskell-src-exts >= 1.18   && < 1.24,
     mtl              >= 2.0    && < 2.3,
     semigroups       >= 0.18   && < 0.20,
     syb              >= 0.3    && < 0.8,
@@ -83,7 +83,7 @@ Executable stylish-haskell
     directory        >= 1.2.3  && < 1.4,
     filepath         >= 1.1    && < 1.5,
     file-embed       >= 0.0.10 && < 0.1,
-    haskell-src-exts >= 1.18   && < 1.23,
+    haskell-src-exts >= 1.18   && < 1.24,
     mtl              >= 2.0    && < 2.3,
     syb              >= 0.3    && < 0.8,
     yaml             >= 0.8.11 && < 0.12
@@ -137,7 +137,7 @@ Test-suite stylish-haskell-tests
     directory        >= 1.2.3  && < 1.4,
     filepath         >= 1.1    && < 1.5,
     file-embed       >= 0.0.10 && < 0.1,
-    haskell-src-exts >= 1.18   && < 1.23,
+    haskell-src-exts >= 1.18   && < 1.24,
     mtl              >= 2.0    && < 2.3,
     syb              >= 0.3    && < 0.8,
     yaml             >= 0.8.11 && < 0.12


### PR DESCRIPTION
haskell-src-exts-1.23.0 adds support for BlockArguments :)