### PR TITLE
Support for records formatting

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,10 +56,7 @@ import System.Directory (doesFileExist)
 import qualified Data.Map as M
 import      Data.Map    ((!), keys, Map)
 
-data Point = Point
-    { pointX, pointY :: Double
-    , pointName :: String
-    } deriving (Show)
+data Point = Point { pointX, pointY :: Double , pointName :: String} deriving (Show)
 ```
 
 into:

--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -16,8 +16,7 @@ steps:
   #     add_language_pragma: true
 
   # Format record definitions
-  - records:
-      indent: 4
+  - records: {}
 
   # Align the right hand side of some elements.  This is quite conservative
   # and only applies to statements where each element occupies a single
@@ -225,6 +224,9 @@ steps:
   # elements into single spaces. Basically, this undoes the effect of
   # simple_align but is a bit less conservative.
   # - squash: {}
+
+# A common indentation setting. Different steps take this into account.
+indent: 4
 
 # A common setting is the number of columns (parts of) code will be wrapped
 # to. Different steps take this into account.

--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -221,6 +221,7 @@ steps:
   # elements into single spaces. Basically, this undoes the effect of
   # simple_align but is a bit less conservative.
   # - squash: {}
+  - records: {}
 
 # A common setting is the number of columns (parts of) code will be wrapped
 # to. Different steps take this into account.

--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -15,6 +15,10 @@ steps:
   #     # true.
   #     add_language_pragma: true
 
+  # Format record definitions
+  - records:
+      indent: 4
+
   # Align the right hand side of some elements.  This is quite conservative
   # and only applies to statements where each element occupies a single
   # line. All default to true.
@@ -221,7 +225,6 @@ steps:
   # elements into single spaces. Basically, this undoes the effect of
   # simple_align but is a bit less conservative.
   # - squash: {}
-  - records: {}
 
 # A common setting is the number of columns (parts of) code will be wrapped
 # to. Different steps take this into account.

--- a/lib/Language/Haskell/Stylish.hs
+++ b/lib/Language/Haskell/Stylish.hs
@@ -29,6 +29,7 @@ import           Control.Monad                                    (foldM)
 import           Language.Haskell.Stylish.Config
 import           Language.Haskell.Stylish.Parse
 import           Language.Haskell.Stylish.Step
+import qualified Language.Haskell.Stylish.Step.Data               as Data
 import qualified Language.Haskell.Stylish.Step.Imports            as Imports
 import qualified Language.Haskell.Stylish.Step.LanguagePragmas    as LanguagePragmas
 import qualified Language.Haskell.Stylish.Step.SimpleAlign        as SimpleAlign
@@ -38,6 +39,10 @@ import qualified Language.Haskell.Stylish.Step.UnicodeSyntax      as UnicodeSynt
 import           Language.Haskell.Stylish.Verbose
 import           Paths_stylish_haskell                            (version)
 
+
+--------------------------------------------------------------------------------
+records :: Step
+records = Data.step
 
 --------------------------------------------------------------------------------
 simpleAlign :: Maybe Int  -- ^ Columns

--- a/lib/Language/Haskell/Stylish.hs
+++ b/lib/Language/Haskell/Stylish.hs
@@ -29,7 +29,6 @@ import           Control.Monad                                    (foldM)
 import           Language.Haskell.Stylish.Config
 import           Language.Haskell.Stylish.Parse
 import           Language.Haskell.Stylish.Step
-import qualified Language.Haskell.Stylish.Step.Data               as Data
 import qualified Language.Haskell.Stylish.Step.Imports            as Imports
 import qualified Language.Haskell.Stylish.Step.LanguagePragmas    as LanguagePragmas
 import qualified Language.Haskell.Stylish.Step.SimpleAlign        as SimpleAlign

--- a/lib/Language/Haskell/Stylish.hs
+++ b/lib/Language/Haskell/Stylish.hs
@@ -40,10 +40,6 @@ import           Paths_stylish_haskell                            (version)
 
 
 --------------------------------------------------------------------------------
-records :: Step
-records = Data.step
-
---------------------------------------------------------------------------------
 simpleAlign :: Maybe Int  -- ^ Columns
             -> SimpleAlign.Config
             -> Step

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -184,7 +184,8 @@ parseSimpleAlign c o = SimpleAlign.step
 
 --------------------------------------------------------------------------------
 parseRecords :: Config -> A.Object -> A.Parser Step
-parseRecords _ _ = return Data.step
+parseRecords _ o = Data.step
+    <$> (o A..:? "indent" A..!= 4)
 
 
 --------------------------------------------------------------------------------

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -52,13 +52,13 @@ type Extensions = [String]
 
 --------------------------------------------------------------------------------
 data Config = Config
-  { configSteps              :: [Step]
-  , configIndent             :: Int
-  , configColumns            :: Maybe Int
-  , configLanguageExtensions :: [String]
-  , configNewline            :: IO.Newline
-  , configCabal              :: Bool
-  }
+    { configSteps              :: [Step]
+    , configIndent             :: Int
+    , configColumns            :: Maybe Int
+    , configLanguageExtensions :: [String]
+    , configNewline            :: IO.Newline
+    , configCabal              :: Bool
+    }
 
 
 --------------------------------------------------------------------------------

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -35,6 +35,7 @@ import qualified System.IO                                        as IO (Newline
 import qualified Language.Haskell.Stylish.Config.Cabal            as Cabal
 import           Language.Haskell.Stylish.Config.Internal
 import           Language.Haskell.Stylish.Step
+import qualified Language.Haskell.Stylish.Step.Data               as Data
 import qualified Language.Haskell.Stylish.Step.Imports            as Imports
 import qualified Language.Haskell.Stylish.Step.LanguagePragmas    as LanguagePragmas
 import qualified Language.Haskell.Stylish.Step.SimpleAlign        as SimpleAlign
@@ -141,6 +142,7 @@ parseConfig _            = mzero
 catalog :: Map String (Config -> A.Object -> A.Parser Step)
 catalog = M.fromList
     [ ("imports",             parseImports)
+    , ("records",             parseRecords)
     , ("language_pragmas",    parseLanguagePragmas)
     , ("simple_align",        parseSimpleAlign)
     , ("squash",              parseSquash)
@@ -179,6 +181,10 @@ parseSimpleAlign c o = SimpleAlign.step
         <*> withDef SimpleAlign.cRecords          "records")
   where
     withDef f k = fromMaybe (f SimpleAlign.defaultConfig) <$> (o A..:? k)
+
+--------------------------------------------------------------------------------
+parseRecords :: Config -> A.Object -> A.Parser Step
+parseRecords _ _ = return Data.step
 
 
 --------------------------------------------------------------------------------

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -52,12 +52,13 @@ type Extensions = [String]
 
 --------------------------------------------------------------------------------
 data Config = Config
-    { configSteps              :: [Step]
-    , configColumns            :: Maybe Int
-    , configLanguageExtensions :: [String]
-    , configNewline            :: IO.Newline
-    , configCabal              :: Bool
-    }
+  { configSteps              :: [Step]
+  , configIndent             :: Int
+  , configColumns            :: Maybe Int
+  , configLanguageExtensions :: [String]
+  , configNewline            :: IO.Newline
+  , configCabal              :: Bool
+  }
 
 
 --------------------------------------------------------------------------------
@@ -120,6 +121,7 @@ parseConfig (A.Object o) = do
     -- First load the config without the actual steps
     config <- Config
         <$> pure []
+        <*> (o A..:? "indent"              A..!= 4)
         <*> (o A..:! "columns"             A..!= Just 80)
         <*> (o A..:? "language_extensions" A..!= [])
         <*> (o A..:? "newline"             >>= parseEnum newlines IO.nativeNewline)
@@ -184,8 +186,8 @@ parseSimpleAlign c o = SimpleAlign.step
 
 --------------------------------------------------------------------------------
 parseRecords :: Config -> A.Object -> A.Parser Step
-parseRecords _ o = Data.step
-    <$> (o A..:? "indent" A..!= 4)
+parseRecords c _ = Data.step
+    <$> pure (configIndent c)
 
 
 --------------------------------------------------------------------------------

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -1,12 +1,10 @@
 module Language.Haskell.Stylish.Step.Data where
 
 import qualified Language.Haskell.Exts           as H
-import qualified Language.Haskell.Exts.Syntax    as H
 
 import           Language.Haskell.Stylish.Block
 import           Language.Haskell.Stylish.Editor
 import           Language.Haskell.Stylish.Step
-import           Language.Haskell.Stylish.Util
 
 datas :: H.Module l -> [(l, H.Decl l)]
 datas modu =
@@ -15,6 +13,7 @@ datas modu =
     , H.DataDecl l b c d e f                  <- decls
     ]
 
+type ChangeLine = Change String
 
 step :: Step
 step = makeStep "Data" step'
@@ -23,6 +22,7 @@ step' :: Lines -> Module -> Lines
 step' ls (module', _) = applyChanges changes ls
   where
     datas' = datas $ fmap linesFromSrcSpan module'
-    changes = fmap (delete . fst) datas'
+    changes = datas' >>= changeDecl
 
-prettyDataDecls = undefined
+changeDecl :: (LineBlock, H.Decl l)  -> [ChangeLine]
+changeDecl (block,  _) = [change block ("-- this is a comment" : )]

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -1,0 +1,6 @@
+module Language.Haskell.Stylish.Step.Data where
+
+import           Language.Haskell.Stylish.Step
+
+step :: Step
+step = makeStep "Data" const

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -36,12 +36,11 @@ changeDecl indentSize (block, H.DataDecl _ (H.DataType _) Nothing dhead decls de
     newLines :: [[String]]
     newLines = (fmap (\(decl, i) -> if (i == 1) then processConstructor typeConstructor decl else processConstructor (indented "| ") decl) zipped) ++ [fmap (\d -> indented $ H.prettyPrint d) derivings]
     typeConstructor = "data " <> H.prettyPrint dhead <> " = "
-    firstName (fnames, _type) = indented "{ " <> intercalate ", " (fmap H.prettyPrint fnames) <> " :: " <> H.prettyPrint _type
-    otherName (fnames, _type) = indented ", " <> intercalate ", " (fmap H.prettyPrint fnames) <> " :: " <> H.prettyPrint _type
+    processName init (fnames, _type) = indented init <> intercalate ", " (fmap H.prettyPrint fnames) <> " :: " <> H.prettyPrint _type
     extractField (H.FieldDecl _ names _type) = (names, _type)
 
     processConstructor init (H.QualConDecl _ _ _ (H.RecDecl _ dname fields)) = do
-      init <> H.prettyPrint dname : (firstName $ extractField $ head fields) : (fmap (otherName . extractField) (tail fields)) ++ [indented "}"]
+      init <> H.prettyPrint dname : (processName "{ " $ extractField $ head fields) : (fmap (processName ", " . extractField) (tail fields)) ++ [indented "}"]
     processConstructor init decl = [init <> trimLeft (H.prettyPrint decl)]
 
     indented str = indent indentSize str

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -25,11 +25,11 @@ step' ls (module', _) = applyChanges changes ls
     changes = datas' >>= (maybeToList . changeDecl)
 
 changeDecl :: (LineBlock, H.Decl l)  -> Maybe ChangeLine
-changeDecl (block, H.DataDecl _ (H.DataType _) _ (H.DHead _ ident) [(H.QualConDecl _ _ _ (H.RecDecl _ dname fields))] _) =
+changeDecl (block, H.DataDecl _ (H.DataType _) _ dhead [(H.QualConDecl _ _ _ (H.RecDecl _ dname fields))] _) =
   Just $ change block (const newLines)
   where
     newLines = typeConstructor : (firstName $ extractField $ head fields) : (fmap (otherName . extractField) (tail fields)) ++ ["  }"]
-    typeConstructor = "data " <> H.prettyPrint ident <> " = " <> H.prettyPrint dname
+    typeConstructor = "data " <> H.prettyPrint dhead <> " = " <> H.prettyPrint dname
     firstName (fname, _type) = "  { " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type
     otherName (fname, _type) = "  , " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type
     extractField (H.FieldDecl _ names _type) = (head names, _type)

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -27,6 +27,7 @@ step' indentSize ls (module', _) = applyChanges changes ls
     changes = datas' >>= (maybeToList . (changeDecl indentSize))
 
 changeDecl :: Int -> (LineBlock, H.Decl l)  -> Maybe ChangeLine
+changeDecl _ (_, H.DataDecl _ (H.DataType _) Nothing _ [] _) = Nothing
 changeDecl indentSize (block, H.DataDecl _ (H.DataType _) Nothing dhead decls derivings) =
   Just $ change block (const $ concat newLines)
   where

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -1,7 +1,7 @@
 module Language.Haskell.Stylish.Step.Data where
 
+import           Data.Maybe                      (maybeToList)
 import qualified Language.Haskell.Exts           as H
-
 import           Language.Haskell.Stylish.Block
 import           Language.Haskell.Stylish.Editor
 import           Language.Haskell.Stylish.Step
@@ -22,17 +22,15 @@ step' :: Lines -> Module -> Lines
 step' ls (module', _) = applyChanges changes ls
   where
     datas' = datas $ fmap linesFromSrcSpan module'
-    changes = datas' >>= changeDecl
+    changes = datas' >>= (maybeToList . changeDecl)
 
-changeDecl :: (LineBlock, H.Decl l)  -> [ChangeLine]
-changeDecl (block, H.DataDecl _ (H.DataType _) _ (H.DHead _ ident) qualConDecls _) = do
-  (H.QualConDecl _ _ _ (H.RecDecl _ dname fields)) <- qualConDecls
-  (H.FieldDecl _ names _type) <- fields
-  fname <- names
-  [change block (\_ ->
-                   ["data " <> H.prettyPrint ident <> " = " <> H.prettyPrint dname
-                   ,"  { " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type
-                   ,"  }"
-                   ]
-                )]
-changeDecl _ = []
+changeDecl :: (LineBlock, H.Decl l)  -> Maybe ChangeLine
+changeDecl (block, H.DataDecl _ (H.DataType _) _ (H.DHead _ ident) [(H.QualConDecl _ _ _ (H.RecDecl _ dname fields))] _) =
+  Just $ change block (const newLines)
+  where
+    newLines = typeConstructor : (firstName $ extractField $ head fields) : (fmap (otherName . extractField) (tail fields)) ++ ["  }"]
+    typeConstructor = "data " <> H.prettyPrint ident <> " = " <> H.prettyPrint dname
+    firstName (fname, _type) = "  { " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type
+    otherName (fname, _type) = "  , " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type
+    extractField (H.FieldDecl _ names _type) = (head names, _type)
+changeDecl _ = Nothing

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -1,6 +1,7 @@
 module Language.Haskell.Stylish.Step.Data where
 
 import           Prelude hiding (init)
+import           Data.List (intercalate)
 import           Data.Maybe                      (maybeToList)
 import qualified Language.Haskell.Exts           as H
 import           Language.Haskell.Stylish.Block
@@ -35,9 +36,9 @@ changeDecl indentSize (block, H.DataDecl _ (H.DataType _) Nothing dhead decls de
     newLines :: [[String]]
     newLines = (fmap (\(decl, i) -> if (i == 1) then processConstructor typeConstructor decl else processConstructor (indented "| ") decl) zipped) ++ [fmap (\d -> indented $ H.prettyPrint d) derivings]
     typeConstructor = "data " <> H.prettyPrint dhead <> " = "
-    firstName (fname, _type) = indented "{ " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type
-    otherName (fname, _type) = indented ", " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type
-    extractField (H.FieldDecl _ names _type) = (head names, _type)
+    firstName (fnames, _type) = indented "{ " <> intercalate ", " (fmap H.prettyPrint fnames) <> " :: " <> H.prettyPrint _type
+    otherName (fnames, _type) = indented ", " <> intercalate ", " (fmap H.prettyPrint fnames) <> " :: " <> H.prettyPrint _type
+    extractField (H.FieldDecl _ names _type) = (names, _type)
 
     processConstructor init (H.QualConDecl _ _ _ (H.RecDecl _ dname fields)) = do
       init <> H.prettyPrint dname : (firstName $ extractField $ head fields) : (fmap (otherName . extractField) (tail fields)) ++ [indented "}"]

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -27,7 +27,7 @@ step' indentSize ls (module', _) = applyChanges changes ls
     changes = datas' >>= (maybeToList . (changeDecl indentSize))
 
 changeDecl :: Int -> (LineBlock, H.Decl l)  -> Maybe ChangeLine
-changeDecl indentSize (block, H.DataDecl _ (H.DataType _) _ dhead decls derivings) =
+changeDecl indentSize (block, H.DataDecl _ (H.DataType _) Nothing dhead decls derivings) =
   Just $ change block (const $ concat newLines)
   where
     zipped = zip decls ([1..] ::[Int])

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -1,13 +1,13 @@
 module Language.Haskell.Stylish.Step.Data where
 
-import           Prelude hiding (init)
-import           Data.List (intercalate)
+import           Data.List                       (intercalate)
 import           Data.Maybe                      (maybeToList)
 import qualified Language.Haskell.Exts           as H
 import           Language.Haskell.Stylish.Block
 import           Language.Haskell.Stylish.Editor
 import           Language.Haskell.Stylish.Step
 import           Language.Haskell.Stylish.Util
+import           Prelude                         hiding (init)
 
 datas :: H.Module l -> [(l, H.Decl l)]
 datas modu =
@@ -25,7 +25,7 @@ step' :: Int -> Lines -> Module -> Lines
 step' indentSize ls (module', _) = applyChanges changes ls
   where
     datas' = datas $ fmap linesFromSrcSpan module'
-    changes = datas' >>= (maybeToList . (changeDecl indentSize))
+    changes = datas' >>= maybeToList . changeDecl indentSize
 
 changeDecl :: Int -> (LineBlock, H.Decl l)  -> Maybe ChangeLine
 changeDecl _ (_, H.DataDecl _ (H.DataType _) Nothing _ [] _) = Nothing
@@ -34,15 +34,15 @@ changeDecl indentSize (block, H.DataDecl _ (H.DataType _) Nothing dhead decls de
   where
     zipped = zip decls ([1..] ::[Int])
     newLines :: [[String]]
-    newLines = (fmap (\(decl, i) -> if (i == 1) then processConstructor typeConstructor decl else processConstructor (indented "| ") decl) zipped) ++ [fmap (\d -> indented $ H.prettyPrint d) derivings]
+    newLines = fmap (\(decl, i) -> if i == 1 then processConstructor typeConstructor decl else processConstructor (indented "| ") decl) zipped ++ [fmap (indented . H.prettyPrint) derivings]
     typeConstructor = "data " <> H.prettyPrint dhead <> " = "
     processName init (fnames, _type) = indented init <> intercalate ", " (fmap H.prettyPrint fnames) <> " :: " <> H.prettyPrint _type
     extractField (H.FieldDecl _ names _type) = (names, _type)
 
-    processConstructor init (H.QualConDecl _ _ _ (H.RecDecl _ dname fields)) = do
-      init <> H.prettyPrint dname : (processName "{ " $ extractField $ head fields) : (fmap (processName ", " . extractField) (tail fields)) ++ [indented "}"]
+    processConstructor init (H.QualConDecl _ _ _ (H.RecDecl _ dname fields)) =
+      init <> H.prettyPrint dname : processName "{ " ( extractField $ head fields) : fmap (processName ", " . extractField) (tail fields) ++ [indented "}"]
     processConstructor init decl = [init <> trimLeft (H.prettyPrint decl)]
 
-    indented str = indent indentSize str
+    indented = indent indentSize
 
 changeDecl _ _ = Nothing

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -1,6 +1,28 @@
 module Language.Haskell.Stylish.Step.Data where
 
+import qualified Language.Haskell.Exts           as H
+import qualified Language.Haskell.Exts.Syntax    as H
+
+import           Language.Haskell.Stylish.Block
+import           Language.Haskell.Stylish.Editor
 import           Language.Haskell.Stylish.Step
+import           Language.Haskell.Stylish.Util
+
+datas :: H.Module l -> [(l, H.Decl l)]
+datas modu =
+    [ (l, H.DataDecl l b c d e f)
+    | H.Module _ _ _ _ decls                  <- [modu]
+    , H.DataDecl l b c d e f                  <- decls
+    ]
+
 
 step :: Step
-step = makeStep "Data" const
+step = makeStep "Data" step'
+
+step' :: Lines -> Module -> Lines
+step' ls (module', _) = applyChanges changes ls
+  where
+    datas' = datas $ fmap linesFromSrcSpan module'
+    changes = fmap (delete . fst) datas'
+
+prettyDataDecls = undefined

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -3,13 +3,14 @@ module Language.Haskell.Stylish.Step.Data where
 import           Data.List                       (intercalate)
 import           Data.Maybe                      (maybeToList)
 import qualified Language.Haskell.Exts           as H
+import           Language.Haskell.Exts.Comments
 import           Language.Haskell.Stylish.Block
 import           Language.Haskell.Stylish.Editor
 import           Language.Haskell.Stylish.Step
 import           Language.Haskell.Stylish.Util
 import           Prelude                         hiding (init)
 
-datas :: H.Module l -> [H.Decl l]
+datas :: H.Module (l, c) -> [H.Decl (l, c)]
 datas (H.Module _ _ _ _ decls) = decls
 datas _                        = []
 
@@ -19,14 +20,15 @@ step :: Int -> Step
 step indentSize = makeStep "Data" (step' indentSize)
 
 step' :: Int -> Lines -> Module -> Lines
-step' indentSize ls (module', _) = applyChanges changes ls
+step' indentSize ls module' = applyChanges changes ls
   where
-    datas' = datas $ fmap linesFromSrcSpan module'
+    module'' = associateHaddock module'
+    datas' = datas $ fmap (\(i, c) -> (linesFromSrcSpan i, c)) module''
     changes = datas' >>= maybeToList . changeDecl indentSize
 
-changeDecl :: Int -> H.Decl LineBlock -> Maybe ChangeLine
+changeDecl :: Int -> H.Decl (LineBlock, [Comment]) -> Maybe ChangeLine
 changeDecl _ (H.DataDecl _ (H.DataType _) Nothing _ [] _) = Nothing
-changeDecl indentSize (H.DataDecl block (H.DataType _) Nothing dhead decls derivings) =
+changeDecl indentSize (H.DataDecl (block, _) (H.DataType _) Nothing dhead decls derivings) =
   Just $ change block (const $ concat newLines)
   where
     newLines = fmap constructors zipped ++ [fmap (indented . H.prettyPrint) derivings]
@@ -37,12 +39,12 @@ changeDecl indentSize (H.DataDecl block (H.DataType _) Nothing dhead decls deriv
     indented = indent indentSize
 changeDecl _ _ = Nothing
 
-processConstructor :: String -> Int -> H.QualConDecl l -> [String]
+processConstructor :: String -> Int -> H.QualConDecl (LineBlock, [Comment]) -> [String]
 processConstructor init indentSize (H.QualConDecl _ _ _ (H.RecDecl _ dname fields)) =
   init <> H.prettyPrint dname : processName "{ " ( extractField $ head fields) : fmap (processName ", " . extractField) (tail fields) ++ [indented "}"]
   where
-    processName prefix (fnames, _type) =
-      indented prefix <> intercalate ", " (fmap H.prettyPrint fnames) <> " :: " <> H.prettyPrint _type
-    extractField (H.FieldDecl _ names _type) = (names, _type)
+    processName prefix (fnames, _type, comments) =
+      indented prefix <> intercalate ", " (fmap H.prettyPrint fnames) <> " :: " <> H.prettyPrint _type <> (concat $ fmap show comments)
+    extractField (H.FieldDecl (_, comments) names _type) = (names, _type, comments)
     indented = indent indentSize
 processConstructor init _ decl = [init <> trimLeft (H.prettyPrint decl)]

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -16,28 +16,29 @@ datas modu =
 
 type ChangeLine = Change String
 
-step :: Step
-step = makeStep "Data" step'
+step :: Int -> Step
+step indent = makeStep "Data" (step' indent)
 
-step' :: Lines -> Module -> Lines
-step' ls (module', _) = applyChanges changes ls
+step' :: Int -> Lines -> Module -> Lines
+step' indent ls (module', _) = applyChanges changes ls
   where
     datas' = datas $ fmap linesFromSrcSpan module'
-    changes = datas' >>= (maybeToList . changeDecl)
+    changes = datas' >>= (maybeToList . (changeDecl indent))
 
-changeDecl :: (LineBlock, H.Decl l)  -> Maybe ChangeLine
-changeDecl (block, H.DataDecl _ (H.DataType _) _ dhead decls _) =
+changeDecl :: Int -> (LineBlock, H.Decl l)  -> Maybe ChangeLine
+changeDecl indent (block, H.DataDecl _ (H.DataType _) _ dhead decls _) =
   Just $ change block (const $ concat newLines)
   where
     zipped = zip decls [1..]
-    newLines = fmap (\(decl, i) -> if (i == 1) then processConstructor typeConstructor decl else processConstructor "  | " decl) zipped
+    newLines = fmap (\(decl, i) -> if (i == 1) then processConstructor typeConstructor decl else processConstructor (indented "| ") decl) zipped
     typeConstructor = "data " <> H.prettyPrint dhead <> " = "
-    firstName (fname, _type) = "  { " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type
-    otherName (fname, _type) = "  , " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type
+    firstName (fname, _type) = indented "{ " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type
+    otherName (fname, _type) = indented ", " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type
     extractField (H.FieldDecl _ names _type) = (head names, _type)
 
     processConstructor init (H.QualConDecl _ _ _ (H.RecDecl _ dname fields)) = do
-      init <> H.prettyPrint dname : (firstName $ extractField $ head fields) : (fmap (otherName . extractField) (tail fields)) ++ ["  }"]
+      init <> H.prettyPrint dname : (firstName $ extractField $ head fields) : (fmap (otherName . extractField) (tail fields)) ++ [indented "}"]
     processConstructor init decl = [init <> trimLeft (H.prettyPrint decl)]
 
-changeDecl _ = Nothing
+    indented str = (replicate indent ' ') <> str
+changeDecl _ _ = Nothing

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -9,12 +9,9 @@ import           Language.Haskell.Stylish.Step
 import           Language.Haskell.Stylish.Util
 import           Prelude                         hiding (init)
 
-datas :: H.Module l -> [(l, H.Decl l)]
-datas modu =
-    [ (l, H.DataDecl l b c d e f)
-    | H.Module _ _ _ _ decls                  <- [modu]
-    , H.DataDecl l b c d e f                  <- decls
-    ]
+datas :: H.Module l -> [H.Decl l]
+datas (H.Module _ _ _ _ decls) = decls
+datas _                        = []
 
 type ChangeLine = Change String
 
@@ -27,9 +24,9 @@ step' indentSize ls (module', _) = applyChanges changes ls
     datas' = datas $ fmap linesFromSrcSpan module'
     changes = datas' >>= maybeToList . changeDecl indentSize
 
-changeDecl :: Int -> (LineBlock, H.Decl l)  -> Maybe ChangeLine
-changeDecl _ (_, H.DataDecl _ (H.DataType _) Nothing _ [] _) = Nothing
-changeDecl indentSize (block, H.DataDecl _ (H.DataType _) Nothing dhead decls derivings) =
+changeDecl :: Int -> H.Decl LineBlock -> Maybe ChangeLine
+changeDecl _ (H.DataDecl _ (H.DataType _) Nothing _ [] _) = Nothing
+changeDecl indentSize (H.DataDecl block (H.DataType _) Nothing dhead decls derivings) =
   Just $ change block (const $ concat newLines)
   where
     newLines = fmap constructors zipped ++ [fmap (indented . H.prettyPrint) derivings]

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -33,8 +33,10 @@ changeDecl indentSize (block, H.DataDecl _ (H.DataType _) Nothing dhead decls de
   Just $ change block (const $ concat newLines)
   where
     zipped = zip decls ([1..] ::[Int])
-    newLines :: [[String]]
-    newLines = fmap (\(decl, i) -> if i == 1 then processConstructor typeConstructor decl else processConstructor (indented "| ") decl) zipped ++ [fmap (indented . H.prettyPrint) derivings]
+    newLines = fmap constructors zipped ++ [fmap (indented . H.prettyPrint) derivings]
+
+    constructors (decl, 1) = processConstructor typeConstructor decl
+    constructors (decl, _) = processConstructor (indented "| ") decl
     typeConstructor = "data " <> H.prettyPrint dhead <> " = "
     processName init (fnames, _type) = indented init <> intercalate ", " (fmap H.prettyPrint fnames) <> " :: " <> H.prettyPrint _type
     extractField (H.FieldDecl _ names _type) = (names, _type)

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -5,6 +5,7 @@ import qualified Language.Haskell.Exts           as H
 import           Language.Haskell.Stylish.Block
 import           Language.Haskell.Stylish.Editor
 import           Language.Haskell.Stylish.Step
+import           Language.Haskell.Stylish.Util
 
 datas :: H.Module l -> [(l, H.Decl l)]
 datas modu =
@@ -37,6 +38,6 @@ changeDecl (block, H.DataDecl _ (H.DataType _) _ dhead decls _) =
 
     processConstructor init (H.QualConDecl _ _ _ (H.RecDecl _ dname fields)) = do
       init <> H.prettyPrint dname : (firstName $ extractField $ head fields) : (fmap (otherName . extractField) (tail fields)) ++ ["  }"]
-    processConstructor _ _ = []
+    processConstructor init decl = [init <> trimLeft (H.prettyPrint decl)]
 
 changeDecl _ = Nothing

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -25,4 +25,14 @@ step' ls (module', _) = applyChanges changes ls
     changes = datas' >>= changeDecl
 
 changeDecl :: (LineBlock, H.Decl l)  -> [ChangeLine]
-changeDecl (block,  _) = [change block ("-- this is a comment" : )]
+changeDecl (block, H.DataDecl _ (H.DataType _) _ (H.DHead _ ident) qualConDecls _) = do
+  (H.QualConDecl _ _ _ (H.RecDecl _ dname fields)) <- qualConDecls
+  (H.FieldDecl _ names _type) <- fields
+  fname <- names
+  [change block (\_ ->
+                   ["data " <> H.prettyPrint ident <> " = " <> H.prettyPrint dname
+                   ,"  { " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type
+                   ,"  }"
+                   ]
+                )]
+changeDecl _ = []

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -27,11 +27,12 @@ step' indentSize ls (module', _) = applyChanges changes ls
     changes = datas' >>= (maybeToList . (changeDecl indentSize))
 
 changeDecl :: Int -> (LineBlock, H.Decl l)  -> Maybe ChangeLine
-changeDecl indentSize (block, H.DataDecl _ (H.DataType _) _ dhead decls _) =
+changeDecl indentSize (block, H.DataDecl _ (H.DataType _) _ dhead decls derivings) =
   Just $ change block (const $ concat newLines)
   where
     zipped = zip decls ([1..] ::[Int])
-    newLines = fmap (\(decl, i) -> if (i == 1) then processConstructor typeConstructor decl else processConstructor (indented "| ") decl) zipped
+    newLines :: [[String]]
+    newLines = (fmap (\(decl, i) -> if (i == 1) then processConstructor typeConstructor decl else processConstructor (indented "| ") decl) zipped) ++ [fmap (\d -> indented $ H.prettyPrint d) derivings]
     typeConstructor = "data " <> H.prettyPrint dhead <> " = "
     firstName (fname, _type) = indented "{ " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type
     otherName (fname, _type) = indented ", " <> H.prettyPrint fname <> " :: " <> H.prettyPrint _type

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -1,6 +1,7 @@
 module Language.Haskell.Stylish.Step.Data where
 
 import           Data.List                       (intercalate)
+import           Data.List                       (find)
 import           Data.Maybe                      (maybeToList)
 import qualified Language.Haskell.Exts           as H
 import           Language.Haskell.Exts.Comments
@@ -22,35 +23,51 @@ step indentSize = makeStep "Data" (step' indentSize)
 step' :: Int -> Lines -> Module -> Lines
 step' indentSize ls module' = applyChanges changes ls
   where
+    allComments = snd module'
     module'' = associateHaddock module'
     datas' = datas $ fmap (\(i, c) -> (linesFromSrcSpan i, c)) module''
-    changes = datas' >>= maybeToList . changeDecl indentSize
+    changes = datas' >>= maybeToList . changeDecl allComments indentSize
 
-changeDecl :: Int -> H.Decl (LineBlock, [Comment]) -> Maybe ChangeLine
-changeDecl _ (H.DataDecl _ (H.DataType _) Nothing _ [] _) = Nothing
-changeDecl indentSize (H.DataDecl (block, _) (H.DataType _) Nothing dhead decls derivings) =
-  fmap (\l -> change block (const $ concat l)) newLines
+findComment :: LineBlock -> [Comment] -> Maybe Comment
+findComment lb = find foo
+  where
+    foo (Comment _ (H.SrcSpan _ start _ end _) _) =
+      (blockStart lb) == start && (blockEnd lb) == end
+
+commentWithin :: LineBlock -> [Comment] -> Maybe Comment
+commentWithin lb = find foo
+  where
+    foo (Comment _ (H.SrcSpan _ start _ end _) _) =
+      start >= (blockStart lb) && end <= (blockEnd lb)
+
+changeDecl :: [Comment] -> Int -> H.Decl (LineBlock, [Comment]) -> Maybe ChangeLine
+changeDecl _ _ (H.DataDecl _ (H.DataType _) Nothing _ [] _) = Nothing
+changeDecl allComments indentSize (H.DataDecl (block, _) (H.DataType _) Nothing dhead decls derivings)
+  | commentWithin block allComments == Nothing = fmap (\l -> change block (const $ concat l)) newLines
+  | otherwise = Nothing
   where
     newLines = if Nothing `elem` maybeConstructors then Nothing
        else Just $ fmap concat maybeConstructors ++ [fmap (indented . H.prettyPrint) derivings]
     maybeConstructors :: [Maybe [String]]
     maybeConstructors = fmap constructors zipped
     zipped = zip decls ([1..] ::[Int])
-    constructors (decl, 1) = processConstructor typeConstructor indentSize decl
-    constructors (decl, _) = processConstructor (indented "| ") indentSize decl
+    constructors (decl, 1) = processConstructor allComments typeConstructor indentSize decl
+    constructors (decl, _) = processConstructor allComments (indented "| ") indentSize decl
     typeConstructor = "data " <> H.prettyPrint dhead <> " = "
     indented = indent indentSize
-changeDecl _ _ = Nothing
+changeDecl _ _ _ = Nothing
 
-processConstructor :: String -> Int -> H.QualConDecl (LineBlock, [Comment]) -> Maybe [String]
-processConstructor init indentSize (H.QualConDecl _ _ _ (H.RecDecl _ dname fields)) = do
+processConstructor :: [Comment] -> String -> Int -> H.QualConDecl (LineBlock, [Comment]) -> Maybe [String]
+processConstructor allComments init indentSize (H.QualConDecl _ _ _ (H.RecDecl _ dname fields)) = do
   n1 <- processName "{ " ( extractField $ head fields)
   ns <- traverse (processName ", " . extractField) (tail fields)
   Just $ init <> H.prettyPrint dname : n1 : ns ++ [indented "}"]
   where
-    processName prefix (fnames, _type, []) = Just $
+    processName prefix (fnames, _type, Nothing) = Just $
       indented prefix <> intercalate ", " (fmap H.prettyPrint fnames) <> " :: " <> H.prettyPrint _type
-    processName _ _ = Nothing
-    extractField (H.FieldDecl (_, comments) names _type) = (names, _type, comments)
+    processName prefix (fnames, _type, (Just (Comment _ _ c))) = Just $
+      indented prefix <> intercalate ", " (fmap H.prettyPrint fnames) <> " :: " <> H.prettyPrint _type <> " --" <> c
+    -- processName _ _ = Nothing
+    extractField (H.FieldDecl (lb, _) names _type) = (names, _type, findComment lb allComments)
     indented = indent indentSize
-processConstructor init _ decl = Just [init <> trimLeft (H.prettyPrint decl)]
+processConstructor _ init _ decl = Just [init <> trimLeft (H.prettyPrint decl)]

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -1,8 +1,7 @@
 module Language.Haskell.Stylish.Step.Data where
 
-import           Data.List                       (intercalate)
-import           Data.List                       (find)
-import           Data.Maybe                      (maybeToList)
+import           Data.List                       (find, intercalate)
+import           Data.Maybe                      (isNothing, maybeToList)
 import qualified Language.Haskell.Exts           as H
 import           Language.Haskell.Exts.Comments
 import           Language.Haskell.Stylish.Block
@@ -11,7 +10,7 @@ import           Language.Haskell.Stylish.Step
 import           Language.Haskell.Stylish.Util
 import           Prelude                         hiding (init)
 
-datas :: H.Module (l, c) -> [H.Decl (l, c)]
+datas :: H.Module l -> [H.Decl l]
 datas (H.Module _ _ _ _ decls) = decls
 datas _                        = []
 
@@ -21,29 +20,27 @@ step :: Int -> Step
 step indentSize = makeStep "Data" (step' indentSize)
 
 step' :: Int -> Lines -> Module -> Lines
-step' indentSize ls module' = applyChanges changes ls
+step' indentSize ls (module', allComments) = applyChanges changes ls
   where
-    allComments = snd module'
-    module'' = associateHaddock module'
-    datas' = datas $ fmap (\(i, c) -> (linesFromSrcSpan i, c)) module''
+    datas' = datas $ fmap linesFromSrcSpan module'
     changes = datas' >>= maybeToList . changeDecl allComments indentSize
 
 findComment :: LineBlock -> [Comment] -> Maybe Comment
 findComment lb = find foo
   where
     foo (Comment _ (H.SrcSpan _ start _ end _) _) =
-      (blockStart lb) == start && (blockEnd lb) == end
+      blockStart lb == start && blockEnd lb == end
 
 commentWithin :: LineBlock -> [Comment] -> Maybe Comment
 commentWithin lb = find foo
   where
     foo (Comment _ (H.SrcSpan _ start _ end _) _) =
-      start >= (blockStart lb) && end <= (blockEnd lb)
+      start >= blockStart lb && end <= blockEnd lb
 
-changeDecl :: [Comment] -> Int -> H.Decl (LineBlock, [Comment]) -> Maybe ChangeLine
+changeDecl :: [Comment] -> Int -> H.Decl LineBlock -> Maybe ChangeLine
 changeDecl _ _ (H.DataDecl _ (H.DataType _) Nothing _ [] _) = Nothing
-changeDecl allComments indentSize (H.DataDecl (block, _) (H.DataType _) Nothing dhead decls derivings)
-  | commentWithin block allComments == Nothing = fmap (\l -> change block (const $ concat l)) newLines
+changeDecl allComments indentSize (H.DataDecl block (H.DataType _) Nothing dhead decls derivings)
+  | isNothing $ commentWithin block allComments = fmap (\l -> change block (const $ concat l)) newLines
   | otherwise = Nothing
   where
     newLines = if Nothing `elem` maybeConstructors then Nothing
@@ -57,7 +54,7 @@ changeDecl allComments indentSize (H.DataDecl (block, _) (H.DataType _) Nothing 
     indented = indent indentSize
 changeDecl _ _ _ = Nothing
 
-processConstructor :: [Comment] -> String -> Int -> H.QualConDecl (LineBlock, [Comment]) -> Maybe [String]
+processConstructor :: [Comment] -> String -> Int -> H.QualConDecl LineBlock -> Maybe [String]
 processConstructor allComments init indentSize (H.QualConDecl _ _ _ (H.RecDecl _ dname fields)) = do
   n1 <- processName "{ " ( extractField $ head fields)
   ns <- traverse (processName ", " . extractField) (tail fields)
@@ -67,7 +64,6 @@ processConstructor allComments init indentSize (H.QualConDecl _ _ _ (H.RecDecl _
       indented prefix <> intercalate ", " (fmap H.prettyPrint fnames) <> " :: " <> H.prettyPrint _type
     processName prefix (fnames, _type, (Just (Comment _ _ c))) = Just $
       indented prefix <> intercalate ", " (fmap H.prettyPrint fnames) <> " :: " <> H.prettyPrint _type <> " --" <> c
-    -- processName _ _ = Nothing
-    extractField (H.FieldDecl (lb, _) names _type) = (names, _type, findComment lb allComments)
+    extractField (H.FieldDecl lb names _type) = (names, _type, findComment lb allComments)
     indented = indent indentSize
 processConstructor _ init _ decl = Just [init <> trimLeft (H.prettyPrint decl)]

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -29,6 +29,7 @@ Library
 
   Exposed-modules:
     Language.Haskell.Stylish
+    Language.Haskell.Stylish.Step.Data
     Language.Haskell.Stylish.Step.Imports
     Language.Haskell.Stylish.Step.LanguagePragmas
     Language.Haskell.Stylish.Step.SimpleAlign
@@ -107,6 +108,8 @@ Test-suite stylish-haskell-tests
     Language.Haskell.Stylish.Step
     Language.Haskell.Stylish.Step.Imports
     Language.Haskell.Stylish.Step.Imports.Tests
+    Language.Haskell.Stylish.Step.Data
+    Language.Haskell.Stylish.Step.Data.Tests
     Language.Haskell.Stylish.Step.LanguagePragmas
     Language.Haskell.Stylish.Step.LanguagePragmas.Tests
     Language.Haskell.Stylish.Step.SimpleAlign

--- a/tests/Language/Haskell/Stylish/Config/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Config/Tests.hs
@@ -166,6 +166,7 @@ dotStylish = unlines $
   , "      remove_redundant: true"
   , "  - trailing_whitespace: {}"
   , "  - records: {}"
+  , "indent: 2"
   , "columns: 110"
   , "language_extensions:"
   , "  - TemplateHaskell"

--- a/tests/Language/Haskell/Stylish/Config/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Config/Tests.hs
@@ -165,6 +165,7 @@ dotStylish = unlines $
   , "      align: false"
   , "      remove_redundant: true"
   , "  - trailing_whitespace: {}"
+  , "  - records: {}"
   , "columns: 110"
   , "language_extensions:"
   , "  - TemplateHaskell"

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -18,10 +18,11 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 06" case06
     , testCase "case 07" case07
     , testCase "case 08" case08
+    , testCase "case 09" case09
     ]
 
 case01 :: Assertion
-case01 = expected @=? testStep step input
+case01 = expected @=? testStep (step 2) input
   where
     input = unlines
       [ "module Herp where"
@@ -38,7 +39,7 @@ case01 = expected @=? testStep step input
        ]
 
 case02 :: Assertion
-case02 = expected @=? testStep step input
+case02 = expected @=? testStep (step 2) input
   where
     input = unlines
       [ "module Herp where"
@@ -55,7 +56,7 @@ case02 = expected @=? testStep step input
        ]
 
 case03 :: Assertion
-case03 = expected @=? testStep step input
+case03 = expected @=? testStep (step 2) input
   where
     input = unlines
       [ "module Herp where"
@@ -72,7 +73,7 @@ case03 = expected @=? testStep step input
        ]
 
 case04 :: Assertion
-case04 = expected @=? testStep step input
+case04 = expected @=? testStep (step 2) input
   where
     input = unlines
       [ "module Herp where"
@@ -92,7 +93,7 @@ case04 = expected @=? testStep step input
        ]
 
 case05 :: Assertion
-case05 = expected @=? testStep step input
+case05 = expected @=? testStep (step 2) input
   where
     input = unlines
        [ "module Herp where"
@@ -112,7 +113,7 @@ case05 = expected @=? testStep step input
        ]
 
 case06 :: Assertion
-case06 = expected @=? testStep step input
+case06 = expected @=? testStep (step 2) input
   where
     input = unlines
       [ "module Herp where"
@@ -122,7 +123,7 @@ case06 = expected @=? testStep step input
     expected = input
 
 case07 :: Assertion
-case07 = expected @=? testStep step input
+case07 = expected @=? testStep (step 2) input
   where
     input = unlines
       [ "module Herp where"
@@ -132,7 +133,7 @@ case07 = expected @=? testStep step input
     expected = input
 
 case08 :: Assertion
-case08 = expected @=? testStep step input
+case08 = expected @=? testStep (step 2) input
   where
     input = unlines
       [ "module Herp where"
@@ -145,3 +146,24 @@ case08 = expected @=? testStep step input
       , ""
       , "data Phantom a = Phantom"
       ]
+
+case09 :: Assertion
+case09 = expected @=? testStep (step 4) input
+  where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "data Foo a b = Foo { a :: a, a2 :: String } | Bar { b :: a, c:: b }"
+      ]
+    expected = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo a b = Foo"
+       , "    { a :: a"
+       , "    , a2 :: String"
+       , "    }"
+       , "    | Bar"
+       , "    { b :: a"
+       , "    , c :: b"
+       , "    }"
+       ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -22,6 +22,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 09" case09
     , testCase "case 10" case10
     , testCase "case 11" case11
+    , testCase "case 12" case12
     ]
 
 case00 :: Assertion
@@ -219,4 +220,22 @@ case11 = expected @=? testStep (step 2) input
        , "  { a :: Int"
        , "  }"
        , "  deriving stock (Show)"
+       ]
+
+case12 :: Assertion
+case12 = expected @=? testStep (step 2) input
+  where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "data Point = Point { pointX, pointY :: Double , pointName :: String} deriving (Show)"
+      ]
+
+    expected = unlines
+       [ "module Herp where"
+       , ""
+       , "data Point = Point"
+       , "    { pointX, pointY :: Double"
+       , "    , pointName      :: String"
+       , "    deriving (Show)"
        ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -1,0 +1,31 @@
+module Language.Haskell.Stylish.Step.Data.Tests
+    ( tests
+    ) where
+
+import           Language.Haskell.Stylish.Step.Data
+import           Language.Haskell.Stylish.Tests.Util (testStep)
+import           Test.Framework                      (Test, testGroup)
+import           Test.Framework.Providers.HUnit      (testCase)
+import           Test.HUnit                          (Assertion, (@=?))
+
+tests :: Test
+tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
+    [ testCase "case 01" case01]
+
+simpleInput :: String
+simpleInput = unlines
+  [ "module Herp where"
+  , ""
+  , "data Foo = Foo { a :: Int }"
+  ]
+
+case01 :: Assertion
+case01 = expected @=? testStep step simpleInput
+  where
+    expected = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo = Foo"
+       , "  { a :: Int"
+       , "  }"
+       ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -15,6 +15,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 03" case03
     , testCase "case 04" case04
     , testCase "case 05" case05
+--    , testCase "case 06" case06
     ]
 
 case01 :: Assertion
@@ -108,3 +109,12 @@ case05 = expected @=? testStep step input
        , "  }"
        ]
 
+case06 :: Assertion
+case06 = expected @=? testStep step input
+  where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "data Foo = Foo Int String"
+      ]
+    expected = input

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -25,8 +25,8 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 12" case12
     , testCase "case 13" case13
     , testCase "case 14" case14
---    , testCase "case 15" case15
---    , testCase "case 16" case16
+    , testCase "case 15" case15
+    , testCase "case 16" case16
     ]
 
 case00 :: Assertion
@@ -290,14 +290,14 @@ case15 = expected @=? testStep (step 2) input
       [ "module Herp where"
       , ""
       , "data Foo = Foo"
-      , "  { a :: Int -- comment"
+      , "  { a :: Int -- ^ comment"
       , "  }"
       ]
     expected = unlines
       [ "module Herp where"
       , ""
       , "data Foo = Foo"
-      , "  { a :: Int -- comment"
+      , "  { a :: Int -- ^ comment"
       , "  }"
       ]
 
@@ -309,7 +309,7 @@ case16 = expected @=? testStep (step 2) input
        , ""
        , "data Foo a = Foo"
        , "  { a :: a"
-       , "-- comment"
+       , "-- ^ comment"
        , "  , a2 :: String"
        , "  }"
        ]
@@ -318,7 +318,7 @@ case16 = expected @=? testStep (step 2) input
        , ""
        , "data Foo a = Foo"
        , "  { a :: a"
-       , "-- comment"
+       , "-- ^ comment"
        , "  , a2 :: String"
        , "  }"
        ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -13,6 +13,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     [ testCase "case 01" case01
     , testCase "case 02" case02
     , testCase "case 03" case03
+    , testCase "case 04" case04
     ]
 
 case01 :: Assertion
@@ -63,5 +64,25 @@ case03 = expected @=? testStep step input
        , "data Foo a = Foo"
        , "  { a :: a"
        , "  , a2 :: String"
+       , "  }"
+       ]
+
+case04 :: Assertion
+case04 = expected @=? testStep step input
+  where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "data Foo a = Foo { a :: a, a2 :: String } | Bar { b :: a }"
+      ]
+    expected = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo a = Foo"
+       , "  { a :: a"
+       , "  , a2 :: String"
+       , "  }"
+       , "  | Bar"
+       , "  { b :: a"
        , "  }"
        ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -17,6 +17,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 05" case05
     , testCase "case 06" case06
     , testCase "case 07" case07
+    , testCase "case 08" case08
     ]
 
 case01 :: Assertion
@@ -129,3 +130,18 @@ case07 = expected @=? testStep step input
       , "data Phantom a = Phantom"
       ]
     expected = input
+
+case08 :: Assertion
+case08 = expected @=? testStep step input
+  where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "data Phantom a ="
+      , "  Phantom"
+      ]
+    expected = unlines
+      [ "module Herp where"
+      , ""
+      , "data Phantom a = Phantom"
+      ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -16,6 +16,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 04" case04
     , testCase "case 05" case05
     , testCase "case 06" case06
+    , testCase "case 07" case07
     ]
 
 case01 :: Assertion
@@ -116,5 +117,15 @@ case06 = expected @=? testStep step input
       [ "module Herp where"
       , ""
       , "data Foo = Foo Int String"
+      ]
+    expected = input
+
+case07 :: Assertion
+case07 = expected @=? testStep step input
+  where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "data Phantom a = Phantom"
       ]
     expected = input

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -10,7 +10,8 @@ import           Test.HUnit                          (Assertion, (@=?))
 
 tests :: Test
 tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
-    [ testCase "case 01" case01
+    [ testCase "case 00" case00
+    , testCase "case 01" case01
     , testCase "case 02" case02
     , testCase "case 03" case03
     , testCase "case 04" case04
@@ -22,6 +23,17 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 10" case10
     , testCase "case 11" case11
     ]
+
+case00 :: Assertion
+case00 = expected @=? testStep (step 2) input
+  where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "data Foo"
+      ]
+
+    expected = input
 
 case01 :: Assertion
 case01 = expected @=? testStep (step 2) input

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -23,6 +23,10 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 10" case10
     , testCase "case 11" case11
     , testCase "case 12" case12
+    , testCase "case 13" case13
+    , testCase "case 14" case14
+--    , testCase "case 15" case15
+--    , testCase "case 16" case16
     ]
 
 case00 :: Assertion
@@ -239,4 +243,82 @@ case12 = expected @=? testStep (step 4) input
        , "    , pointName :: String"
        , "    }"
        , "    deriving (Show)"
+       ]
+
+case13 :: Assertion
+case13 = expected @=? testStep (step 2) input
+  where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "-- this is a comment"
+      , "data Foo = Foo { a :: Int }"
+      ]
+    expected = unlines
+      [ "module Herp where"
+      , ""
+      , "-- this is a comment"
+      , "data Foo = Foo"
+      , "  { a :: Int"
+      , "  }"
+      ]
+
+case14 :: Assertion
+case14 = expected @=? testStep (step 2) input
+  where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "{- this is"
+      , "   a comment -}"
+      , "data Foo = Foo { a :: Int }"
+      ]
+    expected = unlines
+      [ "module Herp where"
+      , ""
+      , "{- this is"
+      , "   a comment -}"
+      , "data Foo = Foo"
+      , "  { a :: Int"
+      , "  }"
+      ]
+
+case15 :: Assertion
+case15 = expected @=? testStep (step 2) input
+  where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "data Foo = Foo"
+      , "  { a :: Int -- comment"
+      , "  }"
+      ]
+    expected = unlines
+      [ "module Herp where"
+      , ""
+      , "data Foo = Foo"
+      , "  { a :: Int -- comment"
+      , "  }"
+      ]
+
+case16 :: Assertion
+case16 = expected @=? testStep (step 2) input
+  where
+    input = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo a = Foo"
+       , "  { a :: a"
+       , "-- comment"
+       , "  , a2 :: String"
+       , "  }"
+       ]
+    expected = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo a = Foo"
+       , "  { a :: a"
+       , "-- comment"
+       , "  , a2 :: String"
+       , "  }"
        ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -223,7 +223,7 @@ case11 = expected @=? testStep (step 2) input
        ]
 
 case12 :: Assertion
-case12 = expected @=? testStep (step 2) input
+case12 = expected @=? testStep (step 4) input
   where
     input = unlines
       [ "module Herp where"
@@ -236,6 +236,7 @@ case12 = expected @=? testStep (step 2) input
        , ""
        , "data Point = Point"
        , "    { pointX, pointY :: Double"
-       , "    , pointName      :: String"
+       , "    , pointName :: String"
+       , "    }"
        , "    deriving (Show)"
        ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -15,7 +15,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 03" case03
     , testCase "case 04" case04
     , testCase "case 05" case05
---    , testCase "case 06" case06
+    , testCase "case 06" case06
     ]
 
 case01 :: Assertion

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -10,22 +10,40 @@ import           Test.HUnit                          (Assertion, (@=?))
 
 tests :: Test
 tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
-    [ testCase "case 01" case01]
-
-simpleInput :: String
-simpleInput = unlines
-  [ "module Herp where"
-  , ""
-  , "data Foo = Foo { a :: Int }"
-  ]
+    [ testCase "case 01" case01
+    , testCase "case 02" case02
+    ]
 
 case01 :: Assertion
-case01 = expected @=? testStep step simpleInput
+case01 = expected @=? testStep step input
   where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "data Foo = Foo { a :: Int }"
+      ]
+
     expected = unlines
        [ "module Herp where"
        , ""
        , "data Foo = Foo"
        , "  { a :: Int"
+       , "  }"
+       ]
+
+case02 :: Assertion
+case02 = expected @=? testStep step input
+  where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "data Foo = Foo { a :: Int, a2 :: String }"
+      ]
+    expected = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo = Foo"
+       , "  { a :: Int"
+       , "  , a2 :: String"
        , "  }"
        ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -27,6 +27,8 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 14" case14
     , testCase "case 15" case15
     , testCase "case 16" case16
+    , testCase "case 17" case17
+    , testCase "case 18" case18
     ]
 
 case00 :: Assertion
@@ -289,15 +291,15 @@ case15 = expected @=? testStep (step 2) input
     input = unlines
       [ "module Herp where"
       , ""
-      , "data Foo = Foo"
-      , "  { a :: Int -- ^ comment"
+      , "data Foo = Foo {"
+      , "   a :: Int -- ^ comment"
       , "  }"
       ]
     expected = unlines
       [ "module Herp where"
       , ""
-      , "data Foo = Foo"
-      , "  { a :: Int -- ^ comment"
+      , "data Foo = Foo {"
+      , "   a :: Int -- ^ comment"
       , "  }"
       ]
 
@@ -308,17 +310,59 @@ case16 = expected @=? testStep (step 2) input
        [ "module Herp where"
        , ""
        , "data Foo a = Foo"
-       , "  { a :: a"
+       , "  { a :: a,"
        , "-- ^ comment"
-       , "  , a2 :: String"
+       , "   a2 :: String"
        , "  }"
        ]
     expected = unlines
        [ "module Herp where"
        , ""
        , "data Foo a = Foo"
-       , "  { a :: a"
+       , "  { a :: a,"
        , "-- ^ comment"
-       , "  , a2 :: String"
+       , "   a2 :: String"
+       , "  }"
+       ]
+
+case17 :: Assertion
+case17 = expected @=? testStep (step 2) input
+  where
+    input = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo a = Foo"
+       , "  { a :: a, -- comment"
+       , "   a2 :: String"
+       , "  }"
+       ]
+    expected = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo a = Foo"
+       , "  { a :: a, -- comment"
+       , "   a2 :: String"
+       , "  }"
+       ]
+
+case18 :: Assertion
+case18 = expected @=? testStep (step 2) input
+  where
+    input = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo a = Foo"
+       , "  { a :: a,"
+       , "-- comment "
+       , "   a2 :: String"
+       , "  }"
+       ]
+    expected = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo a = Foo"
+       , "  { a :: a,"
+       , "-- comment "
+       , "   a2 :: String"
        , "  }"
        ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -12,6 +12,7 @@ tests :: Test
 tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     [ testCase "case 01" case01
     , testCase "case 02" case02
+    , testCase "case 03" case03
     ]
 
 case01 :: Assertion
@@ -44,6 +45,23 @@ case02 = expected @=? testStep step input
        , ""
        , "data Foo = Foo"
        , "  { a :: Int"
+       , "  , a2 :: String"
+       , "  }"
+       ]
+
+case03 :: Assertion
+case03 = expected @=? testStep step input
+  where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "data Foo a = Foo { a :: a, a2 :: String }"
+      ]
+    expected = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo a = Foo"
+       , "  { a :: a"
        , "  , a2 :: String"
        , "  }"
        ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -20,6 +20,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 08" case08
     , testCase "case 09" case09
     , testCase "case 10" case10
+    , testCase "case 11" case11
     ]
 
 case01 :: Assertion
@@ -186,4 +187,24 @@ case10 = expected @=? testStep (step 2) input
        , "  }"
        , "  deriving (Eq, Generic)"
        , "  deriving (Show)"
+       ]
+
+case11 :: Assertion
+case11 = expected @=? testStep (step 2) input
+  where
+    input = unlines
+      [ "{-# LANGUAGE DerivingStrategies #-}"
+      , "module Herp where"
+      , ""
+      , "data Foo = Foo { a :: Int } deriving stock (Show)"
+      ]
+
+    expected = unlines
+       [ "{-# LANGUAGE DerivingStrategies #-}"
+       , "module Herp where"
+       , ""
+       , "data Foo = Foo"
+       , "  { a :: Int"
+       , "  }"
+       , "  deriving stock (Show)"
        ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -19,6 +19,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 07" case07
     , testCase "case 08" case08
     , testCase "case 09" case09
+    , testCase "case 10" case10
     ]
 
 case01 :: Assertion
@@ -166,4 +167,23 @@ case09 = expected @=? testStep (step 4) input
        , "    { b :: a"
        , "    , c :: b"
        , "    }"
+       ]
+
+case10 :: Assertion
+case10 = expected @=? testStep (step 2) input
+  where
+    input = unlines
+      [ "module Herp where"
+      , ""
+      , "data Foo = Foo { a :: Int } deriving (Eq, Generic) deriving (Show)"
+      ]
+
+    expected = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo = Foo"
+       , "  { a :: Int"
+       , "  }"
+       , "  deriving (Eq, Generic)"
+       , "  deriving (Show)"
        ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -14,6 +14,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 02" case02
     , testCase "case 03" case03
     , testCase "case 04" case04
+    , testCase "case 05" case05
     ]
 
 case01 :: Assertion
@@ -86,3 +87,24 @@ case04 = expected @=? testStep step input
        , "  { b :: a"
        , "  }"
        ]
+
+case05 :: Assertion
+case05 = expected @=? testStep step input
+  where
+    input = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo = Foo {"
+       , "  a :: Int"
+       , "  , a2 :: String"
+       , "  }"
+       ]
+    expected = unlines
+       [ "module Herp where"
+       , ""
+       , "data Foo = Foo"
+       , "  { a :: Int"
+       , "  , a2 :: String"
+       , "  }"
+       ]
+

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -11,6 +11,7 @@ import           Test.Framework                                         (default
 --------------------------------------------------------------------------------
 import qualified Language.Haskell.Stylish.Config.Tests
 import qualified Language.Haskell.Stylish.Parse.Tests
+import qualified Language.Haskell.Stylish.Step.Data.Tests
 import qualified Language.Haskell.Stylish.Step.Imports.Tests
 import qualified Language.Haskell.Stylish.Step.LanguagePragmas.Tests
 import qualified Language.Haskell.Stylish.Step.SimpleAlign.Tests
@@ -25,6 +26,7 @@ main :: IO ()
 main = defaultMain
     [ Language.Haskell.Stylish.Parse.Tests.tests
     , Language.Haskell.Stylish.Config.Tests.tests
+    , Language.Haskell.Stylish.Step.Data.Tests.tests
     , Language.Haskell.Stylish.Step.Imports.Tests.tests
     , Language.Haskell.Stylish.Step.LanguagePragmas.Tests.tests
     , Language.Haskell.Stylish.Step.SimpleAlign.Tests.tests


### PR DESCRIPTION
(Optionally) turns this:
```
module Herp where

data Foo a = Foo { a :: Int, a2 :: String } | Bar { b :: a } 
```
into
```
module Herp where

data Foo a = Foo 
  { a :: Int
  , a2 :: String 
  } 
  | Bar
  { b :: a
  }
```