### PR TITLE
Tweak tests

### DIFF
--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -96,6 +96,7 @@ Test-suite stylish-haskell-tests
   Type:           exitcode-stdio-1.0
 
   Other-modules:
+    Language.Haskell.Stylish
     Language.Haskell.StylishSpec
     Language.Haskell.Stylish.Align
     Language.Haskell.Stylish.Block
@@ -126,6 +127,7 @@ Test-suite stylish-haskell-tests
     Language.Haskell.Stylish.Tests.Util
     Language.Haskell.Stylish.Util
     Language.Haskell.Stylish.Verbose
+    Paths_stylish_haskell
 
   Build-depends:
     HUnit                >= 1.2 && < 1.7,

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -97,7 +97,6 @@ Test-suite stylish-haskell-tests
 
   Other-modules:
     Language.Haskell.Stylish
-    Language.Haskell.StylishSpec
     Language.Haskell.Stylish.Align
     Language.Haskell.Stylish.Block
     Language.Haskell.Stylish.Config
@@ -124,6 +123,7 @@ Test-suite stylish-haskell-tests
     Language.Haskell.Stylish.Step.TrailingWhitespace.Tests
     Language.Haskell.Stylish.Step.UnicodeSyntax
     Language.Haskell.Stylish.Step.UnicodeSyntax.Tests
+    Language.Haskell.Stylish.Tests
     Language.Haskell.Stylish.Tests.Util
     Language.Haskell.Stylish.Util
     Language.Haskell.Stylish.Verbose

--- a/testdata/test-config.yaml
+++ b/testdata/test-config.yaml
@@ -1,3 +1,0 @@
-steps:
-  - records: {}
-indent: 2

--- a/tests/Language/Haskell/Stylish/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Tests.hs
@@ -1,5 +1,7 @@
 --------------------------------------------------------------------------------
-module Language.Haskell.StylishSpec where
+module Language.Haskell.Stylish.Tests
+    ( tests
+    ) where
 
 
 --------------------------------------------------------------------------------

--- a/tests/Language/Haskell/Stylish/Tests/Util.hs
+++ b/tests/Language/Haskell/Stylish/Tests/Util.hs
@@ -1,6 +1,19 @@
 module Language.Haskell.Stylish.Tests.Util
     ( testStep
+    , withTestDirTree
     ) where
+
+
+--------------------------------------------------------------------------------
+import           Control.Exception              (bracket, try)
+import           System.Directory               (createDirectory,
+                                                 getCurrentDirectory,
+                                                 getTemporaryDirectory,
+                                                 removeDirectoryRecursive,
+                                                 setCurrentDirectory)
+import           System.FilePath                ((</>))
+import           System.IO.Error                (isAlreadyExistsError)
+import           System.Random                  (randomIO)
 
 
 --------------------------------------------------------------------------------
@@ -15,3 +28,34 @@ testStep step str = case parseModule [] Nothing str of
     Right module' -> unlines $ stepFilter step ls module'
   where
     ls = lines str
+
+
+--------------------------------------------------------------------------------
+-- | Create a temporary directory with a randomised name built from the template
+-- provided
+createTempDirectory :: String -> IO FilePath
+createTempDirectory template  = do
+  tmpRootDir <- getTemporaryDirectory
+  dirId <- randomIO :: IO Word
+  findTempName tmpRootDir dirId
+  where
+    findTempName :: FilePath -> Word -> IO FilePath
+    findTempName tmpRootDir x = do
+      let dirpath = tmpRootDir </> template ++ show x
+      r <- try $ createDirectory dirpath
+      case r of
+        Right _ -> return dirpath
+        Left  e | isAlreadyExistsError e -> findTempName tmpRootDir (x+1)
+                | otherwise              -> ioError e
+
+
+--------------------------------------------------------------------------------
+-- | Perform an action inside a temporary directory tree and purge the tree
+-- afterwards
+withTestDirTree :: IO a -> IO a
+withTestDirTree action = bracket
+    ((,) <$> getCurrentDirectory <*> createTempDirectory "stylish_haskell")
+    (\(current, temp) ->
+        setCurrentDirectory current *>
+        removeDirectoryRecursive temp)
+    (\(_, temp) -> setCurrentDirectory temp *> action)

--- a/tests/Language/Haskell/StylishSpec.hs
+++ b/tests/Language/Haskell/StylishSpec.hs
@@ -1,15 +1,18 @@
+--------------------------------------------------------------------------------
 module Language.Haskell.StylishSpec where
 
+
 --------------------------------------------------------------------------------
-import           Test.Framework                 (Test, testGroup)
-import           Test.Framework.Providers.HUnit (testCase)
-import           Test.HUnit                     (Assertion, (@?=))
+import           Test.Framework                      (Test, testGroup)
+import           Test.Framework.Providers.HUnit      (testCase)
+import           Test.HUnit                          (Assertion, (@?=))
+
 
 --------------------------------------------------------------------------------
 import           Language.Haskell.Stylish
+import           Language.Haskell.Stylish.Tests.Util
 
---------------------------------------------------------------------------------
-import           System.IO.Unsafe
+
 --------------------------------------------------------------------------------
 tests :: Test
 tests = testGroup "Language.Haskell.Stylish.Step.Tabs.Tests"
@@ -18,9 +21,10 @@ tests = testGroup "Language.Haskell.Stylish.Step.Tabs.Tests"
     , testCase "case 03" case03
     ]
 
+
 --------------------------------------------------------------------------------
 case01 :: Assertion
-case01 = (@?=) result (unsafePerformIO $ format Nothing Nothing input)
+case01 = (@?= result) =<< format Nothing Nothing input
   where
     input = "module Herp where\n data Foo = Bar | Baz"
     result = Right [ "module Herp where"
@@ -28,20 +32,29 @@ case01 = (@?=) result (unsafePerformIO $ format Nothing Nothing input)
                    , "    | Baz"
                    ]
 
+
+--------------------------------------------------------------------------------
 case02 :: Assertion
-case02 = (@?=) result (unsafePerformIO $ format (Just configLocation) Nothing input)
+case02 = withTestDirTree $ do
+    writeFile "test-config.yaml" $ unlines
+        [ "steps:"
+        , "  - records: {}"
+        , "indent: 2"
+        ]
+
+    actual <- format (Just $ ConfigPath "test-config.yaml") Nothing input
+    actual @?= result
   where
-    configLocation = ConfigPath "testdata/test-config.yaml"
     input = "module Herp where\n data Foo = Bar | Baz"
     result = Right [ "module Herp where"
                    , "data Foo = Bar"
                    , "  | Baz"
                    ]
 
+
+--------------------------------------------------------------------------------
 case03 :: Assertion
-case03 = do
-  actual <- format Nothing (Just fileLocation) input
-  actual @?= result
+case03 = (@?= result) =<< format Nothing (Just fileLocation) input
   where
     fileLocation = "directory/File.hs"
     input = "module Herp"

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -19,14 +19,13 @@ import qualified Language.Haskell.Stylish.Step.Squash.Tests
 import qualified Language.Haskell.Stylish.Step.Tabs.Tests
 import qualified Language.Haskell.Stylish.Step.TrailingWhitespace.Tests
 import qualified Language.Haskell.Stylish.Step.UnicodeSyntax.Tests
-import qualified Language.Haskell.StylishSpec
+import qualified Language.Haskell.Stylish.Tests
 
 
 --------------------------------------------------------------------------------
 main :: IO ()
 main = defaultMain
-    [ Language.Haskell.StylishSpec.tests
-    , Language.Haskell.Stylish.Parse.Tests.tests
+    [ Language.Haskell.Stylish.Parse.Tests.tests
     , Language.Haskell.Stylish.Config.Tests.tests
     , Language.Haskell.Stylish.Step.Data.Tests.tests
     , Language.Haskell.Stylish.Step.Imports.Tests.tests
@@ -36,4 +35,5 @@ main = defaultMain
     , Language.Haskell.Stylish.Step.Tabs.Tests.tests
     , Language.Haskell.Stylish.Step.TrailingWhitespace.Tests.tests
     , Language.Haskell.Stylish.Step.UnicodeSyntax.Tests.tests
+    , Language.Haskell.Stylish.Tests.tests
     ]


### PR DESCRIPTION
Minor test tweaks:
 -  Move `withTestDirTree` to the util module so it can be reused
 -  Use the `withTestDirTree` function in the `Stylish` tests
 -  Rename the `StylishSpec` file to the `.Tests` scheme