### PR TITLE
Recursing directories to find Haskell source files.

### DIFF
--- a/lib/Language/Haskell/Stylish.hs
+++ b/lib/Language/Haskell/Stylish.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 --------------------------------------------------------------------------------
 module Language.Haskell.Stylish
     ( -- * Run
@@ -114,8 +115,7 @@ format maybeConfigPath maybeFilePath contents = do
 findFiles :: Bool -> Maybe FilePath -> IO [FilePath]
 findFiles _ Nothing    = return []
 findFiles v (Just dir) = do
-  existsDir <- doesDirectoryExist dir
-  case existsDir of
+  doesDirectoryExist dir >>= \case
     True  -> findFilesRecursive dir >>=
       return . filter (\x -> takeExtension x == ".hs")
     False -> do
@@ -131,8 +131,7 @@ findFiles v (Just dir) = do
       ps <- listDirectory topdir >>=
         mapM (\x -> do
                  let path = topdir </> x
-                 existsDir <- doesDirectoryExist path
-                 case existsDir of
+                 doesDirectoryExist path >>= \case
                    True  -> go path
                    False -> return [path])
       return $ concat ps

--- a/lib/Language/Haskell/Stylish.hs
+++ b/lib/Language/Haskell/Stylish.hs
@@ -11,7 +11,7 @@ module Language.Haskell.Stylish
     , trailingWhitespace
     , unicodeSyntax
       -- ** Helpers
-    , findFiles
+    , findHaskellFiles
     , stepName
       -- * Config
     , module Language.Haskell.Stylish.Config
@@ -113,14 +113,14 @@ format maybeConfigPath maybeFilePath contents = do
 
 --------------------------------------------------------------------------------
 -- | Searches Haskell source files in any given folder recursively.
-findFiles :: Bool -> [FilePath] -> IO [FilePath]
-findFiles v fs = mapM (findFilesR v . Just) fs >>= return . concat
+findHaskellFiles :: Bool -> [FilePath] -> IO [FilePath]
+findHaskellFiles v fs = mapM (findFilesR v) fs >>= return . concat
 
 
 --------------------------------------------------------------------------------
-findFilesR :: Bool -> Maybe FilePath -> IO [FilePath]
-findFilesR _ Nothing    = return []
-findFilesR v (Just dir) = do
+findFilesR :: Bool -> FilePath -> IO [FilePath]
+findFilesR _ []   = return []
+findFilesR v dir = do
   doesFileExist dir >>= \case
     True -> return [dir]
     _    -> doesDirectoryExist dir >>= \case
@@ -128,7 +128,7 @@ findFilesR v (Just dir) = do
         return . filter (\x -> takeExtension x == ".hs")
       False -> do
         makeVerbose v ("Input folder does not exists: " <> dir)
-        findFilesR v Nothing
+        findFilesR v []
   where
     findFilesRecursive :: FilePath -> IO [FilePath]
     findFilesRecursive = listDirectoryFiles findFilesRecursive

--- a/lib/Language/Haskell/Stylish.hs
+++ b/lib/Language/Haskell/Stylish.hs
@@ -120,14 +120,14 @@ findHaskellFiles v fs = mapM (findFilesR v) fs >>= return . concat
 --------------------------------------------------------------------------------
 findFilesR :: Bool -> FilePath -> IO [FilePath]
 findFilesR _ []   = return []
-findFilesR v dir = do
-  doesFileExist dir >>= \case
-    True -> return [dir]
-    _    -> doesDirectoryExist dir >>= \case
-      True  -> findFilesRecursive dir >>=
+findFilesR v path = do
+  doesFileExist path >>= \case
+    True -> return [path]
+    _    -> doesDirectoryExist path >>= \case
+      True  -> findFilesRecursive path >>=
         return . filter (\x -> takeExtension x == ".hs")
       False -> do
-        makeVerbose v ("Input folder does not exists: " <> dir)
+        makeVerbose v ("Input folder does not exists: " <> path)
         findFilesR v []
   where
     findFilesRecursive :: FilePath -> IO [FilePath]
@@ -138,8 +138,8 @@ findFilesR v dir = do
     listDirectoryFiles go topdir = do
       ps <- listDirectory topdir >>=
         mapM (\x -> do
-                 let path = topdir </> x
-                 doesDirectoryExist path >>= \case
-                   True  -> go path
-                   False -> return [path])
+                 let dir = topdir </> x
+                 doesDirectoryExist dir >>= \case
+                   True  -> go dir
+                   False -> return [dir])
       return $ concat ps

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -10,7 +10,7 @@ import qualified Data.ByteString.Char8    as BC8
 import           Data.Monoid              ((<>))
 import           Data.Version             (showVersion)
 import qualified Options.Applicative      as OA
-import           System.Directory         (listDirectory, doesDirectoryExist)
+import           System.Directory         (doesDirectoryExist, listDirectory)
 import           System.Exit              (exitFailure)
 import           System.FilePath          (takeExtension, (</>))
 import qualified System.IO                as IO
@@ -23,14 +23,14 @@ import           Language.Haskell.Stylish
 
 --------------------------------------------------------------------------------
 data StylishArgs = StylishArgs
-    { saVersion  :: Bool
-    , saConfig   :: Maybe FilePath
-    , saRecursive:: Maybe FilePath
-    , saVerbose  :: Bool
-    , saDefaults :: Bool
-    , saInPlace  :: Bool
-    , saNoUtf8   :: Bool
-    , saFiles    :: [FilePath]
+    { saVersion   :: Bool
+    , saConfig    :: Maybe FilePath
+    , saRecursive :: Maybe FilePath
+    , saVerbose   :: Bool
+    , saDefaults  :: Bool
+    , saInPlace   :: Bool
+    , saNoUtf8    :: Bool
+    , saFiles     :: [FilePath]
     } deriving (Show)
 
 
@@ -120,10 +120,7 @@ stylishHaskell sa = do
 
 
 --------------------------------------------------------------------------------
-{- TODO, Questions:
- - combine this feature with blacklisted folders. (? #200)
- - haskell file extension as an input?
--}
+-- | Searches Haskell source files in any given folder recursively.
 findFiles :: Bool -> Maybe FilePath -> IO [FilePath]
 findFiles _ Nothing    = return []
 findFiles v (Just dir) = do

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -106,7 +106,7 @@ stylishHaskell sa = do
         else do
             conf <- loadConfig verbose' (saConfig sa)
             filesR <- case (saRecursive sa) of
-              True -> findFiles (saVerbose sa) (saFiles sa)
+              True -> findHaskellFiles (saVerbose sa) (saFiles sa)
               _    -> return $ saFiles sa
             let steps = configSteps conf
             forM_ steps $ \s -> verbose' $ "Enabled " ++ stepName s ++ " step"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -10,9 +10,7 @@ import qualified Data.ByteString.Char8    as BC8
 import           Data.Monoid              ((<>))
 import           Data.Version             (showVersion)
 import qualified Options.Applicative      as OA
-import           System.Directory         (doesDirectoryExist, listDirectory)
 import           System.Exit              (exitFailure)
-import           System.FilePath          (takeExtension, (</>))
 import qualified System.IO                as IO
 import qualified System.IO.Strict         as IO.Strict
 
@@ -117,35 +115,6 @@ stylishHaskell sa = do
   where
     verbose' = makeVerbose (saVerbose sa)
     files' x = if null x then [Nothing] else map Just x
-
-
---------------------------------------------------------------------------------
--- | Searches Haskell source files in any given folder recursively.
-findFiles :: Bool -> Maybe FilePath -> IO [FilePath]
-findFiles _ Nothing    = return []
-findFiles v (Just dir) = do
-  existsDir <- doesDirectoryExist dir
-  case existsDir of
-    True  -> findFilesRecursive dir >>=
-      return . filter (\x -> takeExtension x == ".hs")
-    False -> do
-      makeVerbose v ("Input folder does not exists: " <> dir)
-      findFiles v Nothing
-  where
-    findFilesRecursive :: FilePath -> IO [FilePath]
-    findFilesRecursive = listDirectoryFiles findFilesRecursive
-
-    listDirectoryFiles :: (FilePath -> IO [FilePath])
-                       -> FilePath -> IO [FilePath]
-    listDirectoryFiles go topdir = do
-      ps <- listDirectory topdir >>=
-        mapM (\x -> do
-                 let path = topdir </> x
-                 existsDir <- doesDirectoryExist path
-                 case existsDir of
-                   True  -> go path
-                   False -> return [path])
-      return $ concat ps
 
 
 --------------------------------------------------------------------------------

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -115,7 +115,10 @@ stylishHaskell sa = do
             mapM_ (file sa conf) $ files' filesR
   where
     verbose' = makeVerbose (saVerbose sa)
-    files' x = if null x then [Nothing] else map Just x
+    files' x = case (saRecursive sa, null x) of
+      (True,True) -> []         -- No file to format and recursive enabled.
+      (_,True)    -> [Nothing]  -- Involving IO.stdin.
+      (_,False)   -> map Just x -- Process available files.
 
 
 --------------------------------------------------------------------------------

--- a/tests/Language/Haskell/Stylish/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Tests.hs
@@ -7,6 +7,7 @@ module Language.Haskell.Stylish.Tests
 --------------------------------------------------------------------------------
 import           Data.List                           (sort)
 import           System.Directory                    (createDirectory)
+import           System.FilePath                     ((</>))
 import           Test.Framework                      (Test, testGroup)
 import           Test.Framework.Providers.HUnit      (testCase)
 import           Test.HUnit                          (Assertion, (@?=))
@@ -74,12 +75,14 @@ case03 = (@?= result) =<< format Nothing (Just fileLocation) input
 -- | When providing current dir including folders and files.
 case04 :: Assertion
 case04 = withTestDirTree $ do
-  createDirectory "aDir"
-  mapM_ (flip writeFile "") ["b.hs", "c.hx", "a.hs", "aDir/c.hs"]
+  createDirectory aDir
+  mapM_ (flip writeFile "") input
   result <- findFiles False (Just ".")
   sort result @?= sort expected
   where
-    expected = ["./a.hs", "./b.hs", "./aDir/c.hs"]
+    input    = ["b.hs", "c.hx", "a.hs", aDir </> "c.hs"]
+    aDir     = "aDir"
+    expected = map ("." </>) ["a.hs", "b.hs", aDir </> "c.hs"]
 
 
 --------------------------------------------------------------------------------

--- a/tests/Language/Haskell/Stylish/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Tests.hs
@@ -78,7 +78,7 @@ case04 :: Assertion
 case04 = withTestDirTree $ do
   createDirectory aDir >> writeFile c fileCont
   mapM_ (flip writeFile fileCont) fs
-  result <- findFiles False input
+  result <- findHaskellFiles False input
   sort result @?= (sort $ map normalise expected)
   where
     input    = c : fs
@@ -94,7 +94,7 @@ case04 = withTestDirTree $ do
 case05 :: Assertion
 case05 = withTestDirTree $ do
   mapM_ (flip writeFile "") input
-  result <- findFiles False input
+  result <- findHaskellFiles False input
   result @?= expected
   where
     input    = ["b.hs"]
@@ -106,7 +106,7 @@ case05 = withTestDirTree $ do
 case06 :: Assertion
 case06 = withTestDirTree $ do
   mapM_ (flip writeFile "") input
-  result <- findFiles False input
+  result <- findHaskellFiles False input
   result @?= expected
   where
     input    = []

--- a/tests/Language/Haskell/Stylish/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Tests.hs
@@ -21,6 +21,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Tabs.Tests"
     [ testCase "case 01" case01
     , testCase "case 02" case02
     , testCase "case 03" case03
+    , testCase "case 04" case04
     ]
 
 
@@ -64,3 +65,8 @@ case03 = (@?= result) =<< format Nothing (Just fileLocation) input
       "Language.Haskell.Stylish.Parse.parseModule: could not parse " <>
       fileLocation <>
       ": ParseFailed (SrcLoc \"<unknown>.hs\" 2 1) \"Parse error: EOF\""
+
+
+--------------------------------------------------------------------------------
+case04 :: Assertion
+case04 = True @?= False

--- a/tests/Language/Haskell/Stylish/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Tests.hs
@@ -5,6 +5,8 @@ module Language.Haskell.Stylish.Tests
 
 
 --------------------------------------------------------------------------------
+import           Data.List                           (sort)
+import           System.Directory                    (createDirectory)
 import           Test.Framework                      (Test, testGroup)
 import           Test.Framework.Providers.HUnit      (testCase)
 import           Test.HUnit                          (Assertion, (@?=))
@@ -22,6 +24,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Tabs.Tests"
     , testCase "case 02" case02
     , testCase "case 03" case03
     , testCase "case 04" case04
+    , testCase "case 05" case05
     ]
 
 
@@ -68,5 +71,23 @@ case03 = (@?= result) =<< format Nothing (Just fileLocation) input
 
 
 --------------------------------------------------------------------------------
+-- | When providing current dir including folders and files.
 case04 :: Assertion
-case04 = True @?= False
+case04 = withTestDirTree $ do
+  createDirectory "aDir"
+  mapM_ (flip writeFile "") ["b.hs", "c.hx", "a.hs", "aDir/c.hs"]
+  result <- findFiles False (Just ".")
+  sort result @?= sort expected
+  where
+    expected = ["./a.hs", "./b.hs", "./aDir/c.hs"]
+
+
+--------------------------------------------------------------------------------
+-- | When the input is not directory, results in returning [].
+case05 :: Assertion
+case05 = withTestDirTree $ do
+  mapM_ (flip writeFile "") ["b.hs"]
+  result <- findFiles False (Just "./b.hs")
+  result @?= expected
+  where
+    expected = []


### PR DESCRIPTION
This could be one solution to #162 .

There is an added *-r* command-line switch that accepts a folder as its input to search for Haskell source files recursively. In a CI script the already suggested solution in #162 is feasible, however in case _stylish-haskell_ can solve it itself the CI script would become easier.
 
There are pending questions:
- whether you are happy with logging, that is only available in when verbose mode is enabled.
- Could we combine this implementation right away together with #200 ?
- Should the application default to Haskell file extension(s) by default implicitly or should be there another optional argument to specify file extension(s)?


