### PR TITLE
Disable formatting of data types without records

### DIFF
--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -395,5 +395,5 @@ case20 = input @=? testStep (step 2) input
     input = unlines
        [ "module Herp where"
        , ""
-       , "data Tag = Title | Text"
+       , "data Tag = Title | Text deriving (Eq, Show)"
        ]

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -30,6 +30,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 17" case17
     , testCase "case 18" case18
     , testCase "case 19" case19
+    , testCase "case 20 (issue 262)" case20
     ]
 
 case00 :: Assertion
@@ -155,18 +156,13 @@ case07 = expected @=? testStep (step 2) input
     expected = input
 
 case08 :: Assertion
-case08 = expected @=? testStep (step 2) input
+case08 = input @=? testStep (step 2) input
   where
     input = unlines
       [ "module Herp where"
       , ""
       , "data Phantom a ="
       , "  Phantom"
-      ]
-    expected = unlines
-      [ "module Herp where"
-      , ""
-      , "data Phantom a = Phantom"
       ]
 
 case09 :: Assertion
@@ -388,4 +384,16 @@ case19 = expected @=? testStep (step 2) input
        , "  -- ^ names"
        , "  , age :: Int"
        , "  }"
+       ]
+
+-- | Should not break Enums (data without records) formating
+--
+-- See https://github.com/jaspervdj/stylish-haskell/issues/262
+case20 :: Assertion
+case20 = input @=? testStep (step 2) input
+  where
+    input = unlines
+       [ "module Herp where"
+       , ""
+       , "data Tag = Title | Text"
        ]

--- a/tests/Language/Haskell/Stylish/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Tests.hs
@@ -28,10 +28,9 @@ tests = testGroup "Language.Haskell.Stylish.Step.Tabs.Tests"
 case01 :: Assertion
 case01 = (@?= result) =<< format Nothing Nothing input
   where
-    input = "module Herp where\n data Foo = Bar | Baz"
+    input = "module Herp where\ndata Foo = Bar | Baz"
     result = Right [ "module Herp where"
-                   , "data Foo = Bar"
-                   , "    | Baz"
+                   , "data Foo = Bar | Baz"
                    ]
 
 
@@ -47,10 +46,9 @@ case02 = withTestDirTree $ do
     actual <- format (Just $ ConfigPath "test-config.yaml") Nothing input
     actual @?= result
   where
-    input = "module Herp where\n data Foo = Bar | Baz"
+    input = "module Herp where\ndata Foo = Bar | Baz"
     result = Right [ "module Herp where"
-                   , "data Foo = Bar"
-                   , "  | Baz"
+                   , "data Foo = Bar | Baz"
                    ]
 
 

--- a/tests/Language/Haskell/Stylish/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Tests.hs
@@ -28,9 +28,12 @@ tests = testGroup "Language.Haskell.Stylish.Step.Tabs.Tests"
 case01 :: Assertion
 case01 = (@?= result) =<< format Nothing Nothing input
   where
-    input = "module Herp where\ndata Foo = Bar | Baz"
+    input = "module Herp where\ndata Foo = Bar | Baz { baz :: Int }"
     result = Right [ "module Herp where"
-                   , "data Foo = Bar | Baz"
+                   , "data Foo = Bar"
+                   , "    | Baz"
+                   , "    { baz :: Int"
+                   , "    }"
                    ]
 
 
@@ -46,9 +49,12 @@ case02 = withTestDirTree $ do
     actual <- format (Just $ ConfigPath "test-config.yaml") Nothing input
     actual @?= result
   where
-    input = "module Herp where\ndata Foo = Bar | Baz"
+    input = "module Herp where\ndata Foo = Bar | Baz { baz :: Int }"
     result = Right [ "module Herp where"
-                   , "data Foo = Bar | Baz"
+                   , "data Foo = Bar"
+                   , "  | Baz"
+                   , "  { baz :: Int"
+                   , "  }"
                    ]
 
 


### PR DESCRIPTION
Perhaps the safest way for now is to revert to old behavior for data
types -- i.e. do nothing. Attemmpt reformatting only if at least one
constructor has record fields.

Fixes https://github.com/jaspervdj/stylish-haskell/issues/262