### PR TITLE
Add support for absolute indentation in records and same-line derivings.

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -35,13 +35,18 @@ steps:
   #     # Possible values:
   #     # - "same_line" -- "{" and first field goes on the same line as the data constructor.
   #     # - "indent N" -- insert a new line and N spaces from the beginning of the data constructor
+  #     # - "indent absolute N" -- insert a new line and N spaces from the beginning of the line
   #     first_field: "indent 2"
   #
   #     # How many spaces to insert between the column with "," and the beginning of the comment in the next line.
   #     field_comment: 2
   #
-  #     # How many spaces to insert before "deriving" clause. Deriving clauses are always on separate lines.
-  #     deriving: 2
+  #     # How to format the deriving clause.
+  #     # Possible values:
+  #     # - "same_line" -- the deriving clause is inserted after the closing "}".
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the data constructor
+  #     # - "indent absolute N" -- insert a new line and N spaces from the beginning of the line
+  #     deriving: indent absolute 2
 
   # Align the right hand side of some elements.  This is quite conservative
   # and only applies to statements where each element occupies a single

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -197,15 +197,14 @@ parseRecords _ o = Data.step
 
 parseIndent :: A.Value -> A.Parser Data.Indent
 parseIndent = A.withText "Indent" $ \t ->
-  if t == "same_line"
-  then return Data.SameLine
-  else
-    if | "indent absolute " `T.isPrefixOf` t ->
-         Data.IndentAbsolute <$> readNumber 16 t
-       | "indent " `T.isPrefixOf` t ->
-         Data.IndentRelative <$> readNumber 7 t
-       | otherwise ->
-           fail $ "can't parse indent setting: " <> T.unpack t
+  if | t == "same_line" ->
+       return Data.SameLine
+     | "indent absolute " `T.isPrefixOf` t ->
+       Data.IndentAbsolute <$> readNumber 16 t
+     | "indent " `T.isPrefixOf` t ->
+       Data.IndentRelative <$> readNumber 7 t
+     | otherwise ->
+       fail $ "can't parse indent setting: " <> T.unpack t
   where
     readNumber prefix text =
       let toRead = T.unpack $ T.drop prefix text

--- a/tests/Language/Haskell/Stylish/Config/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Config/Tests.hs
@@ -4,11 +4,11 @@ module Language.Haskell.Stylish.Config.Tests
 
 
 --------------------------------------------------------------------------------
-import qualified Data.Set                        as Set
+import qualified Data.Set                            as Set
 import           System.Directory
-import           Test.Framework                  (Test, testGroup)
-import           Test.Framework.Providers.HUnit  (testCase)
-import           Test.HUnit                      (Assertion, assert)
+import           Test.Framework                      (Test, testGroup)
+import           Test.Framework.Providers.HUnit      (testCase)
+import           Test.HUnit                          (Assertion, assert)
 
 
 --------------------------------------------------------------------------------
@@ -152,7 +152,7 @@ dotStylish = unlines $
   , "      equals: \"same_line\""
   , "      first_field: \"indent 2\""
   , "      field_comment: 2"
-  , "      deriving: 4"
+  , "      deriving: \"indent 4\""
   , "columns: 110"
   , "language_extensions:"
   , "  - TemplateHaskell"

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -35,6 +35,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 22" case22
     , testCase "case 23" case23
     , testCase "case 24" case24
+    , testCase "case 25" case25
     ]
 
 case00 :: Assertion
@@ -520,17 +521,45 @@ case24 = expected @=? testStep (step indentIndentStyle) input
        , "  deriving (ToJSON)"
        ]
 
+case25 :: Assertion
+case25 = expected @=? testStep (step sameAbsoluteStyleWithSameLineDeriving) input
+  where
+    input = unlines
+       [ "data Foo a"
+       , "  = Foo { a :: Int,"
+       , "          a2 :: String"
+       , "          -- ^ some haddock"
+       , "        }"
+       , "  | Bar { b :: a }  deriving (Eq, Show)"
+       , "  deriving (ToJSON)"
+       ]
+
+    expected = unlines
+       [ "data Foo a = Foo"
+       , "   { a :: Int"
+       , "   , a2 :: String"
+       , "     -- ^ some haddock"
+       , "   }"
+       , "           | Bar"
+       , "   { b :: a"
+       , "   } deriving (Eq, Show)"
+       , "     deriving (ToJSON)"
+       ]
+
 sameSameStyle :: Config
-sameSameStyle = Config SameLine SameLine 2 2
+sameSameStyle = Config SameLine SameLine 2 (IndentAbsolute 2)
 
 sameIndentStyle :: Config
-sameIndentStyle = Config SameLine (Indent 2) 2 2
+sameIndentStyle = Config SameLine (IndentRelative 2) 2 (IndentAbsolute 2)
 
 indentSameStyle :: Config
-indentSameStyle = Config (Indent 2) SameLine 2 2
+indentSameStyle = Config (IndentRelative 2) SameLine 2 (IndentAbsolute 2)
 
 indentIndentStyle :: Config
-indentIndentStyle = Config (Indent 2) (Indent 2) 2 2
+indentIndentStyle = Config (IndentRelative 2) (IndentRelative 2) 2 (IndentAbsolute 2)
 
 indentIndentStyle4 :: Config
-indentIndentStyle4 = Config (Indent 4) (Indent 4) 4 4
+indentIndentStyle4 = Config (IndentRelative 4) (IndentRelative 4) 4 (IndentAbsolute 4)
+
+sameAbsoluteStyleWithSameLineDeriving :: Config
+sameAbsoluteStyleWithSameLineDeriving = Config SameLine (IndentAbsolute 3) 2 SameLine

--- a/tests/Language/Haskell/Stylish/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Tests.hs
@@ -48,7 +48,7 @@ case02 = withTestDirTree $ do
         , "      equals: \"indent 2\""
         , "      first_field: \"indent 2\""
         , "      field_comment: 2"
-        , "      deriving: 2"
+        , "      deriving: \"indent 2\""
         ]
 
     actual <- format (Just $ ConfigPath "test-config.yaml") Nothing input
@@ -72,7 +72,7 @@ case03 = withTestDirTree $ do
         , "      equals: \"same_line\""
         , "      first_field: \"same_line\""
         , "      field_comment: 2"
-        , "      deriving: 2"
+        , "      deriving: \"indent 2\""
         ]
 
     actual <- format (Just $ ConfigPath "test-config.yaml") Nothing input


### PR DESCRIPTION
## Description

This PR adds more options to record formatting. Specifically, it changes the indent type; indentation can now be specified as either `same_line`, `indent n`, or `indent absolute n`. It also allows for the `deriving` statement to be on the same line as the closing brackets.

The motivation for this is to support the very same formatting style that [stylish-haskell uses internally](https://github.com/jaspervdj/stylish-haskell/blob/master/lib/Language/Haskell/Stylish/Step/Data.hs#L20).

*This PR is a draft and needs some work (see known limitations section).*

<br />

## Absolute indenting

Relative and absolute make no difference for the equal sign, however they do for the first line.

**original formatting**
```
data Foo a = Foo { a :: Int,
                   a2 :: String
                   -- ^ some haddock
                 } deriving (Eq, Show)
```

**with equals = same_line and first_field = indent 2**
```
data Foo a = Foo
               { a :: Int
               , a2 :: String
                 -- ^ some haddock
               }
  deriving (Eq, Show)
```

**with equals = same_line and first_field = indent absolute 2**
```
data Foo a = Foo
  { a :: Int
  , a2 :: String
    -- ^ some haddock
  }
  deriving (Eq, Show)
```

<br />

## Same-line deriving

This changes also changes the deriving option to be an `Indent`; the previous behaviour was to treat it as what is now an absolute indent. This allows for same-line deriving clauses.


**original formatting**
```
data Foo a = Foo { a :: Int,
                   a2 :: String
                   -- ^ some haddock
                 }
  deriving (Eq, Show)
```

**previous behaviour: deriving 2 => absolute indent 2**
```
data Foo a =
  Foo { a :: Int
      , a2 :: String
        -- ^ some haddock
      }
  deriving (Eq, Show)
```

**with deriving = same_line**
```
data Foo a =
  Foo { a :: Int
      , a2 :: String
        -- ^ some haddock
      } deriving (Eq, Show)
```

<br />

## Known limitations

The major issue with this PR is that it is a **BREAKING CHANGE**. Existing configuration using `deriving: 2` will **NOT** work if this PR is submitted. There are two possible approaches to fix this that come to mind:
  - deprecating the `deriving` field, in favour of a new one; if the `deriving` field is present and the new field isn't, use it as an absolute indent
  - allow for the field to be either text or a number; if it's a number, print a deprecation message and interpret the field as an absolute indent.