### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -63,11 +63,14 @@ Library
     file-embed       >= 0.0.10 && < 0.1,
     haskell-src-exts >= 1.18   && < 1.24,
     mtl              >= 2.0    && < 2.3,
-    semigroups       >= 0.18   && < 0.20,
     syb              >= 0.3    && < 0.8,
     text             >= 1.2    && < 1.3,
     HsYAML-aeson     >=0.2.0   && < 0.3,
     HsYAML           >=0.2.0   && < 0.3
+  
+  if impl(ghc < 8.0)
+    Build-depends:
+      semigroups     >= 0.18   && < 0.20
 
 Executable stylish-haskell
   Ghc-options:      -Wall


### PR DESCRIPTION
They are not needed on newer GHC.