### PR TITLE
Allow Cabal 3.2 for test suite

### DIFF
--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -144,7 +144,7 @@ Test-suite stylish-haskell-tests
     aeson            >= 0.6    && < 1.6,
     base             >= 4.8    && < 5,
     bytestring       >= 0.9    && < 0.11,
-    Cabal            >= 2.4    && < 3.1,
+    Cabal            >= 2.4    && < 3.3,
     containers       >= 0.3    && < 0.7,
     directory        >= 1.2.3  && < 1.4,
     filepath         >= 1.1    && < 1.5,


### PR DESCRIPTION
The bounds of Cabal were not updated in 2dd6fbd669e3501d5d4783dfa2d9f9ba3026ea1b

All tests pass here with the new Cabal.