### PR TITLE
Update stack.yaml to an ghc-8.10.2 resolver

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,15 +1,9 @@
-resolver: lts-16.9
+resolver: nightly-2020-08-22
 
 # Specifying `-split-sections` in this way propagates the setting to all
 # dependencies as well. The effect of this is a 50%-60% reduction in final
 # binary size, with effectively no additional compilation time cost.
 ghc-options:
   $everything: -split-sections
-
-extra-deps:
-- 'aeson-1.5.2.0'
-- 'Cabal-3.2.0.0'
-- 'HsYAML-aeson-0.2.0.0@rev:2'
-- 'HsYAML-0.2.1.0@rev:1'
 
 save-hackage-creds: false

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,38 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: aeson-1.5.2.0@sha256:d00c7aa51969b2849550e4dee14c9ce188504d55ed8d7f734ce9f6976db452f6,6786
-    pantry-tree:
-      size: 39758
-      sha256: 992b01282d72e4db664289db69a846a4ec675379ca96824ba902a7541104d409
-  original:
-    hackage: aeson-1.5.2.0
-- completed:
-    hackage: Cabal-3.2.0.0@sha256:d0d7a1f405f25d0000f5ddef684838bc264842304fd4e7f80ca92b997b710874,27320
-    pantry-tree:
-      size: 40963
-      sha256: b122f2d76dc82a350d3986fa0cbc4ecf9c3bb4f9c598ccbfb3b2bfdde02f3698
-  original:
-    hackage: Cabal-3.2.0.0
-- completed:
-    hackage: HsYAML-aeson-0.2.0.0@sha256:b58e8587d480f8c29e4cb4f61ad6ab5d74195d31340e6e8c317ac4d13b65c469,1861
-    pantry-tree:
-      size: 234
-      sha256: 8a181cdb027e2862fd54cb47d0ff91a45126ab4cd2080083128e800c5fa2635b
-  original:
-    hackage: HsYAML-aeson-0.2.0.0@rev:2
-- completed:
-    hackage: HsYAML-0.2.1.0@sha256:6e63cbc919543c5a837040f063e96fe0a4e43bef8ab3c057cef8f122396fdc2d,5469
-    pantry-tree:
-      size: 1340
-      sha256: 77d9299977dfbc7836cbbcb51fe890bb70d485d9dd89a3bbe54822635faa8108
-  original:
-    hackage: HsYAML-0.2.1.0@rev:1
+packages: []
 snapshots:
 - completed:
-    size: 532380
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/9.yaml
-    sha256: 14a7cec114424e4286adde73364438927a553ed248cc50f069a30a67e3ee1e69
-  original: lts-16.9
+    size: 521288
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2020/8/22.yaml
+    sha256: 6dd14e2061dde3a43a356afc7722fb6e4c7cb5986f8abc3d2fbdaad87594bd73
+  original: nightly-2020-08-22

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -77,7 +77,7 @@ Executable stylish-haskell
 
   Build-depends:
     stylish-haskell,
-    strict               >= 0.3  && < 0.4,
+    strict               >= 0.3  && < 0.5,
     optparse-applicative >= 0.12 && < 0.16,
     -- Copied from regular dependencies...
     aeson            >= 0.6    && < 1.6,


### PR DESCRIPTION
- Update the stack build configuration:
  - use a ghc-8.10.2 resolver;
  - remove the `extra-dependencies` section.
- Update the project Cabal file: 
  - update the upper bound on package `strict`. 

Fixes https://github.com/jaspervdj/stylish-haskell/issues/302.