### PR TITLE
Remove split-sections stanza

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,5 @@
 resolver: lts-16.9
 
-# Specifying `-split-sections` in this way propagates the setting to all
-# dependencies as well. The effect of this is a 50%-60% reduction in final
-# binary size, with effectively no additional compilation time cost.
-ghc-options:
-  $everything: -split-sections
-
 extra-deps:
 - 'aeson-1.5.2.0'
 - 'Cabal-3.2.0.0'


### PR DESCRIPTION
The use of `split-sections` in stack.yaml breaks the build on macOS. Fixes https://github.com/jaspervdj/stylish-haskell/issues/304.