### PR TITLE
Fix "group" import sort with multi-line imports

### DIFF
--- a/lib/Language/Haskell/Stylish/Module.hs
+++ b/lib/Language/Haskell/Stylish/Module.hs
@@ -201,10 +201,13 @@ moduleImportGroups = go [] Nothing . moduleImports
         -> [NonEmpty (Located Import)]
     go acc _        []                   = ne acc
     go acc mbCurrentLine (imp : impRest) =
-        let l2 = getStartLineUnsafe imp in
+        let
+          lStart = getStartLineUnsafe imp
+          lEnd = getEndLineUnsafe imp in
         case mbCurrentLine of
-            Just l1 | l1 + 1 < l2 -> ne acc ++ go [imp] (Just l2) impRest
-            _                     -> go (acc ++ [imp]) (Just l2) impRest
+            Just lPrevEnd | lPrevEnd + 1 < lStart
+              -> ne acc ++ go [imp] (Just lEnd) impRest
+            _ -> go (acc ++ [imp]) (Just lEnd) impRest
 
     ne []       = []
     ne (x : xs) = [x :| xs]

--- a/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
@@ -58,6 +58,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Imports.Tests"
     , testCase "case 25" case25
     , testCase "case 26 (issue 185)" case26
     , testCase "case 27" case27
+    , testCase "case 28" case28
     ]
 
 
@@ -877,4 +878,25 @@ case27 = expected @=? testSnippet (step Nothing $ fromImportAlign Global) input
         , "import           Herp.Derp.Internals hiding (foo)"
         , ""
         , "herp = putStrLn \"import Hello world\""
+        ]
+
+--------------------------------------------------------------------------------
+case28 :: Assertion
+case28 = expected @=? testSnippet (step Nothing $ fromImportAlign Group) input'
+  where
+    -- Check that "Group" mode recognizes groups with multi-line imports
+    input' = Snippet
+        [ "import Foo (foo)"
+        , "import BarBar ( bar"
+        , "              , kek)"
+        , "import Abcd ()"
+        , ""
+        , "import A (A)"
+        ]
+    expected = Snippet
+        [ "import Abcd   ()"
+        , "import BarBar (bar, kek)"
+        , "import Foo    (foo)"
+        , ""
+        , "import A (A)"
         ]


### PR DESCRIPTION
When some import line spans multuple lines, e.g. when import list is
long, stylish-haskell breaks a group at this line, leading to bad
result.

This commits makes sure that import groups are recognized solely by
empty lines.

---

I hope it's straightforward from the test case :)
Thanks for this awesome tool. Most likely I will make a couple more PRs in the next few days.