### PR TITLE
Make sorting deriving list optional

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -58,9 +58,12 @@ steps:
   #
   #     # How many spaces to insert before "via" clause counted from indentation of deriving clause
   #     # Possible values:
-  #     # - "same_line" -- "{" and first field goes on the same line as the data constructor.
-  #     # - "indent N" -- insert a new line and N spaces from the beginning of the data constructor
+  #     # - "same_line" -- "via" part goes on the same line as "deriving" keyword.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of "deriving" keyword.
   #     via: "indent 2"
+  #
+  #     # Sort typeclass names in the "deriving" list alphabetically.
+  #     sort_deriving: true
   #
   #     # Wheter or not to break enums onto several lines
   #     #

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -221,6 +221,7 @@ parseRecords c o = Data.step
         <*> (o A..:? "break_single_constructors" A..!= True)
         <*> (o A..: "via" >>= parseIndent)
         <*> (o A..:? "curried_context" A..!= False)
+        <*> (o A..:? "sort_deriving" A..!= True)
         <*> pure configMaxColumns)
   where
     configMaxColumns =

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -71,6 +71,8 @@ data Config = Config
       -- ^ Indentation between @via@ clause and start of deriving column start
     , cCurriedContext          :: !Bool
       -- ^ If true, use curried context. E.g: @allValues :: Enum a => Bounded a => Proxy a -> [a]@
+    , cSortDeriving            :: !Bool
+      -- ^ If true, will sort type classes in a @deriving@ list.
     , cMaxColumns              :: !MaxColumns
     } deriving (Show)
 
@@ -266,7 +268,7 @@ putDeriving Config{..} (L pos clause) = do
       = clause
       & deriv_clause_tys
       & unLocated
-      & sortBy compareOutputable
+      & (if cSortDeriving then sortBy compareOutputable else id)
       & fmap hsib_body
 
     headTy =

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -65,6 +65,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 52" case52
     , testCase "case 53" case53
     , testCase "case 54" case54
+    , testCase "case 55" case55
     ]
 
 case00 :: Assertion
@@ -1200,17 +1201,31 @@ case54 = expected @=? testStep (step indentIndentStyle { cMaxColumns = MaxColumn
       , "  deriving newtype (Applicative, Functor, Monad)"
       ]
 
+case55 :: Assertion
+case55 = expected @=? testStep (step sameSameNoSortStyle) input
+  where
+    input = unlines
+       [ "data Foo = Foo deriving (Z, Y, X, Bar, Abcd)"
+       ]
+
+    expected = unlines
+       [ "data Foo = Foo deriving (Z, Y, X, Bar, Abcd)"
+       ]
+
 sameSameStyle :: Config
-sameSameStyle = Config SameLine SameLine 2 2 False True SameLine False NoMaxColumns
+sameSameStyle = Config SameLine SameLine 2 2 False True SameLine False True NoMaxColumns
 
 sameIndentStyle :: Config
-sameIndentStyle = Config SameLine (Indent 2) 2 2 False True SameLine False NoMaxColumns
+sameIndentStyle = Config SameLine (Indent 2) 2 2 False True SameLine False True NoMaxColumns
 
 indentSameStyle :: Config
-indentSameStyle = Config (Indent 2) SameLine 2 2 False True SameLine False NoMaxColumns
+indentSameStyle = Config (Indent 2) SameLine 2 2 False True SameLine False True NoMaxColumns
 
 indentIndentStyle :: Config
-indentIndentStyle = Config (Indent 2) (Indent 2) 2 2 False True SameLine False NoMaxColumns
+indentIndentStyle = Config (Indent 2) (Indent 2) 2 2 False True SameLine False True NoMaxColumns
 
 indentIndentStyle4 :: Config
-indentIndentStyle4 = Config (Indent 4) (Indent 4) 4 4 False True SameLine False NoMaxColumns
+indentIndentStyle4 = Config (Indent 4) (Indent 4) 4 4 False True SameLine False True NoMaxColumns
+
+sameSameNoSortStyle :: Config
+sameSameNoSortStyle = Config SameLine SameLine 2 2 False True SameLine False False NoMaxColumns

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -1208,9 +1208,7 @@ case55 = expected @=? testStep (step sameSameNoSortStyle) input
        [ "data Foo = Foo deriving (Z, Y, X, Bar, Abcd)"
        ]
 
-    expected = unlines
-       [ "data Foo = Foo deriving (Z, Y, X, Bar, Abcd)"
-       ]
+    expected = input
 
 sameSameStyle :: Config
 sameSameStyle = Config SameLine SameLine 2 2 False True SameLine False True NoMaxColumns


### PR DESCRIPTION
Not everyone wants their typeclasses sorted.