### PR TITLE
Add new option for aligning groups of adjacent items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ cabal-dev
 cabal.config
 cabal.sandbox.config
 cabal.sandbox.config
+cabal.project.local
 dist
 /dist-newstyle/

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,0 +1,1 @@
+tests: true

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,1 +1,0 @@
-tests: true

--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -92,7 +92,7 @@ steps:
   # line.
   # Possible values:
   # - always - Always align statements.
-  # - adjacent - Only align statements that are on adjacent lines in groups. Comments and blank lines.
+  # - adjacent - Align statements that are on adjacent lines in groups.
   # - never - Never align statements.
   # All default to always.
   - simple_align:

--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -89,11 +89,16 @@ steps:
 
   # Align the right hand side of some elements.  This is quite conservative
   # and only applies to statements where each element occupies a single
-  # line. All default to true.
+  # line.
+  # Possible values:
+  # - always - Always align statements.
+  # - adjacent - Only align statements that are on adjacent lines in groups. Comments and blank lines.
+  # - never - Never align statements.
+  # All default to always.
   - simple_align:
-      cases: true
-      top_level_patterns: true
-      records: true
+      cases: always
+      top_level_patterns: always
+      records: always
 
   # Import cleanup
   - imports:

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -206,11 +206,16 @@ parseSimpleAlign :: Config -> A.Object -> A.Parser Step
 parseSimpleAlign c o = SimpleAlign.step
     <$> pure (configColumns c)
     <*> (SimpleAlign.Config
-        <$> withDef SimpleAlign.cCases            "cases"
-        <*> withDef SimpleAlign.cTopLevelPatterns "top_level_patterns"
-        <*> withDef SimpleAlign.cRecords          "records")
+        <$> (o A..:? "cases" >>= parseEnum aligns (def SimpleAlign.cCases))
+        <*> (o A..:? "top_level_patterns" >>= parseEnum aligns (def SimpleAlign.cTopLevelPatterns))
+        <*> (o A..:? "records" >>= parseEnum aligns (def SimpleAlign.cRecords)))
   where
-    withDef f k = fromMaybe (f SimpleAlign.defaultConfig) <$> (o A..:? k)
+    def f = f SimpleAlign.defaultConfig
+    aligns =
+        [ ("always",   SimpleAlign.Always)
+        , ("adjacent", SimpleAlign.Adjacent)
+        , ("never",    SimpleAlign.Never)
+        ]
 
 --------------------------------------------------------------------------------
 parseRecords :: Config -> A.Object -> A.Parser Step

--- a/tests/Language/Haskell/Stylish/Step/SimpleAlign/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/SimpleAlign/Tests.hs
@@ -31,6 +31,9 @@ tests = testGroup "Language.Haskell.Stylish.Step.SimpleAlign.Tests"
     , testCase "case 10" case10
     , testCase "case 11" case11
     , testCase "case 12" case12
+    , testCase "case 13" case13
+    , testCase "case 14" case14
+    , testCase "case 15" case15
     ]
 
 
@@ -192,10 +195,69 @@ case11 = assertSnippet (step Nothing defaultConfig)
 
 --------------------------------------------------------------------------------
 case12 :: Assertion
-case12 = assertSnippet (step Nothing defaultConfig {cCases = False}) input input
+case12 = assertSnippet (step Nothing defaultConfig { cCases = Never }) input input
   where
     input =
         [ "case x of"
         , "  Just y -> 1"
         , "  Nothing -> 2"
         ]
+
+
+--------------------------------------------------------------------------------
+case13 :: Assertion
+case13 = assertSnippet (step (Just 80) defaultConfig { cCases = Adjacent })
+    [ "catch e = case e of"
+    , "    Left GoodError -> 1"
+    , "    Left BadError -> 2"
+    , "    -- otherwise"
+    , "    Right [] -> 0"
+    , "    Right (x:_) -> x"
+    ]
+    [ "catch e = case e of"
+    , "    Left GoodError -> 1"
+    , "    Left BadError  -> 2"
+    , "    -- otherwise"
+    , "    Right []    -> 0"
+    , "    Right (x:_) -> x"
+    ]
+
+
+--------------------------------------------------------------------------------
+case14 :: Assertion
+case14 = assertSnippet (step (Just 80) defaultConfig { cTopLevelPatterns = Adjacent })
+    [ "catch (Left GoodError) = 1"
+    , "catch (Left BadError) = 2"
+    , "-- otherwise"
+    , "catch (Right []) = 0"
+    , "catch (Right (x:_)) = x"
+    ]
+    [ "catch (Left GoodError) = 1"
+    , "catch (Left BadError)  = 2"
+    , "-- otherwise"
+    , "catch (Right [])    = 0"
+    , "catch (Right (x:_)) = x"
+    ]
+
+
+--------------------------------------------------------------------------------
+case15 :: Assertion
+case15 = assertSnippet (step (Just 80) defaultConfig { cRecords = Adjacent })
+    [ "data Foo = Foo"
+    , "    { foo :: Int"
+    , "    , foo2 :: String"
+    , "      -- a comment"
+    , "    , barqux :: String"
+    , "    , baz :: String"
+    , "    , baz2 :: Bool"
+    , "    } deriving (Show)"
+    ]
+    [ "data Foo = Foo"
+    , "    { foo  :: Int"
+    , "    , foo2 :: String"
+    , "      -- a comment"
+    , "    , barqux :: String"
+    , "    , baz    :: String"
+    , "    , baz2   :: Bool"
+    , "    } deriving (Show)"
+    ]

--- a/tests/Language/Haskell/Stylish/Step/SimpleAlign/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/SimpleAlign/Tests.hs
@@ -35,6 +35,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.SimpleAlign.Tests"
     , testCase "case 14" case14
     , testCase "case 15" case15
     , testCase "case 16" case16
+    , testCase "case 17" case17
     ]
 
 
@@ -274,4 +275,19 @@ case16 = assertSnippet (step (Just 80) defaultConfig { cRecords = Adjacent })
     , "    , baz    :: String"
     , "    , baz2   :: Bool"
     , "    } deriving (Show)"
+    ]
+
+
+--------------------------------------------------------------------------------
+case17 :: Assertion
+case17 = assertSnippet (step Nothing defaultConfig { cCases = Adjacent })
+    [ "cond n = if"
+    , "    | n < 10, x <- 1 -> x"
+    , "    -- comment"
+    , "    | otherwise -> 2"
+    ]
+    [ "cond n = if"
+    , "    | n < 10, x <- 1 -> x"
+    , "    -- comment"
+    , "    | otherwise -> 2"
     ]


### PR DESCRIPTION
This changes the `SimpleAlign` step to have a new option where it only aligns groups of items. This is so that items separated by blank lines or comments won't be aligned, since those are usually far away visually.

```hs
-- Before:
xor mx my = case (mx, my) of
  -- Both are the same.
  (Just _, Just _) -> Nothing
  (Nothing, Nothing) -> Nothing
  -- Both are different.
  (Just left, Nothing) -> Just x
  (Nothing, Just right) -> Just y
```

```hs
-- After:
xor mx my = case (mx, my) of
  -- Both are the same.
  (Just _, Just _)   -> Nothing
  (Nothing, Nothing) -> Nothing
  -- Both are different.
  (Just left, Nothing)  -> Just x
  (Nothing, Just right) -> Just y
```

This depends on #323.
