### PR TITLE
Add `break_only_where` option

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -30,6 +30,9 @@ steps:
   #
   #     # See `separate_lists` for the `imports` step.
   #     separate_lists: true
+  #
+  #     # Whether to break the "where" if there are no exports.
+  #     break_only_where: true
 
   # Format record definitions. This is disabled by default.
   #

--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -32,7 +32,7 @@ steps:
   #     separate_lists: true
   #
   #     # Whether to break the "where" if there are no exports.
-  #     break_only_where: true
+  #     break_only_where: false
 
   # Format record definitions. This is disabled by default.
   #

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -197,9 +197,10 @@ parseEnum strs _   (Just k) = case lookup k strs of
 --------------------------------------------------------------------------------
 parseModuleHeader :: Config -> A.Object -> A.Parser Step
 parseModuleHeader _ o = fmap ModuleHeader.step $ ModuleHeader.Config
-    <$> o A..:? "indent"         A..!= ModuleHeader.indent        def
-    <*> o A..:? "sort"           A..!= ModuleHeader.sort          def
-    <*> o A..:? "separate_lists" A..!= ModuleHeader.separateLists def
+    <$> o A..:? "indent"           A..!= ModuleHeader.indent         def
+    <*> o A..:? "sort"             A..!= ModuleHeader.sort           def
+    <*> o A..:? "separate_lists"   A..!= ModuleHeader.separateLists  def
+    <*> o A..:? "break_only_where" A..!= ModuleHeader.breakOnlyWhere def
   where
     def = ModuleHeader.defaultConfig
 

--- a/lib/Language/Haskell/Stylish/Step/ModuleHeader.hs
+++ b/lib/Language/Haskell/Stylish/Step/ModuleHeader.hs
@@ -40,16 +40,18 @@ import qualified Language.Haskell.Stylish.Step.Imports as Imports
 
 
 data Config = Config
-    { indent        :: Int
-    , sort          :: Bool
-    , separateLists :: Bool
+    { indent         :: Int
+    , sort           :: Bool
+    , separateLists  :: Bool
+    , breakOnlyWhere :: Bool
     }
 
 defaultConfig :: Config
 defaultConfig = Config
-    { indent        = 4
-    , sort          = True
-    , separateLists = True
+    { indent         = 4
+    , sort           = True
+    , separateLists  = True
+    , breakOnlyWhere = True
     }
 
 step :: Config -> Step
@@ -140,10 +142,15 @@ printHeader conf mname mexps _ = do
     putText (showOutputable name)
     attachEolComment loc
 
-  maybe
-    (when (isJust mname) do newline >> spaces (indent conf) >> putText "where")
-    (printExportList conf)
-    mexps
+  case mexps of
+    Nothing -> when (isJust mname) do
+      if breakOnlyWhere conf
+        then do
+          newline
+          spaces (indent conf)
+        else space
+      putText "where"
+    Just exps -> printExportList conf exps
 
 attachEolComment :: SrcSpan -> P ()
 attachEolComment = \case

--- a/lib/Language/Haskell/Stylish/Step/ModuleHeader.hs
+++ b/lib/Language/Haskell/Stylish/Step/ModuleHeader.hs
@@ -51,7 +51,7 @@ defaultConfig = Config
     { indent         = 4
     , sort           = True
     , separateLists  = True
-    , breakOnlyWhere = True
+    , breakOnlyWhere = False
     }
 
 step :: Config -> Step

--- a/tests/Language/Haskell/Stylish/Step/ModuleHeader/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/ModuleHeader/Tests.hs
@@ -17,7 +17,7 @@ import           Language.Haskell.Stylish.Tests.Util
 --------------------------------------------------------------------------------
 tests :: Test
 tests = testGroup "Language.Haskell.Stylish.Printer.ModuleHeader"
-    [ testCase "Hello world" ex0
+    [ testCase "Does not indent absent export list" ex0
     , testCase "Empty exports list" ex1
     , testCase "Single exported variable" ex2
     , testCase "Multiple exported variables" ex3
@@ -29,24 +29,22 @@ tests = testGroup "Language.Haskell.Stylish.Printer.ModuleHeader"
     , testCase "Exports module" ex9
     , testCase "Exports symbol" ex10
     , testCase "Respects groups" ex11
-    , testCase "'where' not repeated in case it isn't part of exports" ex12
-    , testCase "Indents absent export list with 2 spaces" ex13
+    , testCase "'where' not repeated when not part of exports with break_only_where" ex12
+    , testCase "Indents absent export list with 2 spaces with break_only_where" ex13
     , testCase "Indents with 2 spaces" ex14
     , testCase "Group doc with 2 spaces" ex15
     , testCase "Does not sort" ex16
     , testCase "Repects separate_lists" ex17
-    , testCase "Does not break 'where' with no exports" ex18
-    , testCase "Does break 'where' with exports" ex19
+    , testCase "Indents absent export list with break_only_where" ex18
     ]
 
 --------------------------------------------------------------------------------
 ex0 :: Assertion
-ex0 = assertSnippet (step defaultConfig)
-    [ "module Foo where"
-    ]
-    [ "module Foo"
-    , "    where"
-    ]
+ex0 = assertSnippet (step defaultConfig) input input
+  where
+    input =
+      [ "module Foo where"
+      ]
 
 ex1 :: Assertion
 ex1 = assertSnippet (step defaultConfig)
@@ -242,7 +240,7 @@ ex11 = assertSnippet (step defaultConfig)
     ]
 
 ex12 :: Assertion
-ex12 = assertSnippet (step defaultConfig)
+ex12 = assertSnippet (step defaultConfig {breakOnlyWhere = True})
     [ "module Foo"
     , "  where"
     , "-- hmm"
@@ -253,7 +251,7 @@ ex12 = assertSnippet (step defaultConfig)
     ]
 
 ex13 :: Assertion
-ex13 = assertSnippet (step defaultConfig {indent = 2})
+ex13 = assertSnippet (step defaultConfig {breakOnlyWhere = True, indent = 2})
     [ "module Foo where"
     ]
     [ "module Foo"
@@ -315,17 +313,9 @@ ex17 = assertSnippet (step defaultConfig {separateLists = False})
     ]
 
 ex18 :: Assertion
-ex18 = assertSnippet (step defaultConfig {breakOnlyWhere = False}) input input
-  where
-    input =
-      [ "module Foo where"
-      ]
-
-ex19 :: Assertion
-ex19 = assertSnippet (step defaultConfig {breakOnlyWhere = False})
-    [ "module Foo (x) where"
+ex18 = assertSnippet (step defaultConfig {breakOnlyWhere = True})
+    [ "module Foo where"
     ]
     [ "module Foo"
-    , "    ( x"
-    , "    ) where"
+    , "    where"
     ]

--- a/tests/Language/Haskell/Stylish/Step/ModuleHeader/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/ModuleHeader/Tests.hs
@@ -35,6 +35,8 @@ tests = testGroup "Language.Haskell.Stylish.Printer.ModuleHeader"
     , testCase "Group doc with 2 spaces" ex15
     , testCase "Does not sort" ex16
     , testCase "Repects separate_lists" ex17
+    , testCase "Does not break 'where' with no exports" ex18
+    , testCase "Does break 'where' with exports" ex19
     ]
 
 --------------------------------------------------------------------------------
@@ -309,5 +311,21 @@ ex17 = assertSnippet (step defaultConfig {separateLists = False})
     ]
     [ "module Foo"
     , "    ( Bar(..)"
+    , "    ) where"
+    ]
+
+ex18 :: Assertion
+ex18 = assertSnippet (step defaultConfig {breakOnlyWhere = False}) input input
+  where
+    input =
+      [ "module Foo where"
+      ]
+
+ex19 :: Assertion
+ex19 = assertSnippet (step defaultConfig {breakOnlyWhere = False})
+    [ "module Foo (x) where"
+    ]
+    [ "module Foo"
+    , "    ( x"
     , "    ) where"
     ]


### PR DESCRIPTION
Alternatively, make it the default behavior? I don't think I've ever seen someone add a new line before `where` like that before.