### PR TITLE
Add support for .hsc files

### DIFF
--- a/examples/Cpp.hsc
+++ b/examples/Cpp.hsc
@@ -1,0 +1,15 @@
+module Cpp where
+
+#include <something.h>
+
+data Foo = Foo
+    { bar :: Int
+#if 0
+    , bazquux :: Int8
+#else
+    , bazquux :: Int16
+#endif
+    }
+
+main :: IO ()
+main = pure ()

--- a/lib/Language/Haskell/Stylish.hs
+++ b/lib/Language/Haskell/Stylish.hs
@@ -29,6 +29,8 @@ module Language.Haskell.Stylish
 
 --------------------------------------------------------------------------------
 import           Control.Monad                                    (foldM)
+import           Data.Maybe                                       (maybeToList,
+                                                                   mapMaybe)
 import           System.Directory                                 (doesDirectoryExist,
                                                                    doesFileExist,
                                                                    listDirectory)
@@ -47,7 +49,6 @@ import qualified Language.Haskell.Stylish.Step.TrailingWhitespace as TrailingWhi
 import qualified Language.Haskell.Stylish.Step.UnicodeSyntax      as UnicodeSyntax
 import           Language.Haskell.Stylish.Verbose
 import           Paths_stylish_haskell                            (version)
-import Data.Maybe (maybeToList, mapMaybe)
 
 
 --------------------------------------------------------------------------------
@@ -121,6 +122,7 @@ format maybeConfigPath maybeFilePath contents = do
 
 --------------------------------------------------------------------------------
 -- | Searches Haskell source files in any given folder recursively.
+-- Includes any extra extensions to add on top of the config.
 findHaskellFiles :: Bool -> [FilePath] -> IO [(FilePath, [String])]
 findHaskellFiles v fs = mapM (findFilesR v) fs >>= return . concat
 
@@ -151,6 +153,8 @@ findFilesR v path = do
                    False -> return [dir])
       return $ concat ps
 
+-- | Filter out files that can be formatted and also any extra extensions they may use.
+-- Currently supported: .hs .hsc
 considerFiles :: [FilePath] -> [(FilePath, [String])]
 considerFiles = mapMaybe considerFile
 


### PR DESCRIPTION
Closes #328, allowing both `.hsc` files and adding `CPP` to them.
For the future, `considerFiles` could instead return something like `Config -> Config` or `Partial Config` if we want to support more features based on file extension, perhaps `.lhs` files.