### PR TITLE
Keep wildcard if present in IEThingWith

### DIFF
--- a/lib/Language/Haskell/Stylish/Step/Imports.hs
+++ b/lib/Language/Haskell/Stylish/Step/Imports.hs
@@ -323,11 +323,14 @@ printImport _ (IEModuleContents _ (L _ m)) = do
     putText "module"
     space
     putText (moduleNameString m)
-printImport separateLists (IEThingWith _ name _wildcard imps _) = do
+printImport separateLists (IEThingWith _ name wildcard imps _) = do
     printIeWrappedName name
     when separateLists space
+    let ellipsis = case wildcard of
+          IEWildcard _position -> [putText ".."]
+          NoIEWildcard         -> []
     parenthesize $
-      sep (comma >> space) (printIeWrappedName <$> imps)
+      sep (comma >> space) (ellipsis <> fmap printIeWrappedName imps)
 printImport _ (IEGroup _ _ _ ) =
     error "Language.Haskell.Stylish.Printer.Imports.printImportExport: unhandled case 'IEGroup'"
 printImport _ (IEDoc _ _) =

--- a/tests/Language/Haskell/Stylish/Step/ModuleHeader/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/ModuleHeader/Tests.hs
@@ -36,6 +36,7 @@ tests = testGroup "Language.Haskell.Stylish.Printer.ModuleHeader"
     , testCase "Does not sort" ex16
     , testCase "Repects separate_lists" ex17
     , testCase "Indents absent export list with break_only_where" ex18
+    , testCase "Respects bundled patterns" ex19
     ]
 
 --------------------------------------------------------------------------------
@@ -318,4 +319,15 @@ ex18 = assertSnippet (step defaultConfig {breakOnlyWhere = True})
     ]
     [ "module Foo"
     , "    where"
+    ]
+
+ex19 :: Assertion
+ex19 = assertSnippet (step defaultConfig)
+    [ "{-# LANGUAGE PatternSynonyms #-}"
+    , "module Foo (Bar (.., Baz)) where"
+    ]
+    [ "{-# LANGUAGE PatternSynonyms #-}"
+    , "module Foo"
+    , "    ( Bar (.., Baz)"
+    , "    ) where"
     ]


### PR DESCRIPTION
This is necessary to export pattern synonyms bundled with a type. I went with moving the ellipsis to the beginning of the `IEThingWith` list, to match the style from the GHC User's guide, though this could become a setting if there's interest for e.g. moving it to the end.

See https://downloads.haskell.org/ghc/latest/docs/html/users_guide/glasgow_exts.html#import-and-export-of-pattern-synonyms