### PR TITLE
Add break_newtypes flag. (#342)

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -76,6 +76,11 @@ steps:
   #     # Default: false
   #     break_enums: false
   #
+  #     # Whether or not to break newtype types before `=` sign
+  #     #
+  #     # Default: true
+  #     break_newtypes: true
+  #
   #     # Whether or not to break single constructor data types before `=` sign
   #     #
   #     # Default: true

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -235,6 +235,7 @@ parseRecords c o = Data.step
         <*> (o A..: "field_comment")
         <*> (o A..: "deriving")
         <*> (o A..:? "break_enums" A..!= False)
+        <*> (o A..:? "break_newtypes" A..!= True)
         <*> (o A..:? "break_single_constructors" A..!= True)
         <*> (o A..: "via" >>= parseIndent)
         <*> (o A..:? "curried_context" A..!= False)

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -72,6 +72,8 @@ data Config = Config
       -- ^ Indent before @deriving@ lines (measured from column 0)
     , cBreakEnums              :: !Bool
       -- ^ Break enums by newlines and follow the above rules
+    , cBreakNewtypes           :: !Bool
+      -- ^ Break newtypes by newlines and follow the above rules
     , cBreakSingleConstructors :: !Bool
       -- ^ Break single constructors when enabled, e.g. @Indent 2@ will not cause newline after @=@
     , cVia                     :: !Indent
@@ -91,6 +93,7 @@ defaultConfig = Config
     , cFieldComment    = 2
     , cDeriving        = 4
     , cBreakEnums      = True
+    , cBreakNewtypes   = True
     , cBreakSingleConstructors = False
     , cVia             = Indent 4
     , cSortDeriving    = True
@@ -150,7 +153,7 @@ formatDataDecl cfg@Config{..} m ldecl@(L declPos decl) =
             putEolComment declPos
             newline >> spaces x
             pure True
-          (_, _) | not (isNewtype decl) && singleConstructor decl && not cBreakSingleConstructors ->
+          (_, _) | if isNewtype decl then not cBreakNewtypes else singleConstructor decl && not cBreakSingleConstructors ->
             False <$ space
           (Indent x, _)
             | isEnum decl && not cBreakEnums -> False <$ space

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -1292,19 +1292,19 @@ case58 = expected @=? testStep (step sameIndentStyle) input
     expected = input
 
 sameSameStyle :: Config
-sameSameStyle = Config SameLine SameLine 2 2 False True SameLine False True NoMaxColumns
+sameSameStyle = Config SameLine SameLine 2 2 False True True SameLine False True NoMaxColumns
 
 sameIndentStyle :: Config
-sameIndentStyle = Config SameLine (Indent 2) 2 2 False True SameLine False True NoMaxColumns
+sameIndentStyle = Config SameLine (Indent 2) 2 2 False True True SameLine False True NoMaxColumns
 
 indentSameStyle :: Config
-indentSameStyle = Config (Indent 2) SameLine 2 2 False True SameLine False True NoMaxColumns
+indentSameStyle = Config (Indent 2) SameLine 2 2 False True True SameLine False True NoMaxColumns
 
 indentIndentStyle :: Config
-indentIndentStyle = Config (Indent 2) (Indent 2) 2 2 False True SameLine False True NoMaxColumns
+indentIndentStyle = Config (Indent 2) (Indent 2) 2 2 False True True SameLine False True NoMaxColumns
 
 indentIndentStyle4 :: Config
-indentIndentStyle4 = Config (Indent 4) (Indent 4) 4 4 False True SameLine False True NoMaxColumns
+indentIndentStyle4 = Config (Indent 4) (Indent 4) 4 4 False True True SameLine False True NoMaxColumns
 
 sameSameNoSortStyle :: Config
-sameSameNoSortStyle = Config SameLine SameLine 2 2 False True SameLine False False NoMaxColumns
+sameSameNoSortStyle = Config SameLine SameLine 2 2 False True True SameLine False False NoMaxColumns


### PR DESCRIPTION
Default behavior remains the same, but when you set `break_newtypes` to
`false` newtypes will be formatted on a single line.