### PR TITLE
Generalise break_only_where to allow single-line module headers

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -31,8 +31,15 @@ steps:
   #     # See `separate_lists` for the `imports` step.
   #     separate_lists: true
   #
-  #     # Whether to break the "where" if there are no exports.
-  #     break_only_where: false
+  #     # When to break the "where".
+  #     # Possible values:
+  #     # - exports: only break when there is an explicit export list.
+  #     # - single: only break when the export list counts more than one export.
+  #     # - inline: only break when the export list is too long. This is
+  #     #   determined by the `columns` setting. Not applicable when the export
+  #     #   list contains comments as newlines will be required.
+  #     # - always: always break before the "where".
+  #     break_where: exports
 
   # Format record definitions. This is disabled by default.
   #

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -196,13 +196,22 @@ parseEnum strs _   (Just k) = case lookup k strs of
 
 --------------------------------------------------------------------------------
 parseModuleHeader :: Config -> A.Object -> A.Parser Step
-parseModuleHeader _ o = fmap ModuleHeader.step $ ModuleHeader.Config
-    <$> o A..:? "indent"           A..!= ModuleHeader.indent         def
-    <*> o A..:? "sort"             A..!= ModuleHeader.sort           def
-    <*> o A..:? "separate_lists"   A..!= ModuleHeader.separateLists  def
-    <*> o A..:? "break_only_where" A..!= ModuleHeader.breakOnlyWhere def
+parseModuleHeader config o = fmap (ModuleHeader.step columns) $ ModuleHeader.Config
+    <$> (o A..:? "indent"         A..!= ModuleHeader.indent        def)
+    <*> (o A..:? "sort"           A..!= ModuleHeader.sort          def)
+    <*> (o A..:? "separate_lists" A..!= ModuleHeader.separateLists def)
+    <*> (o A..:? "break_where"      >>= parseEnum breakWhere (ModuleHeader.breakWhere def))
   where
     def = ModuleHeader.defaultConfig
+
+    columns = configColumns config
+
+    breakWhere =
+        [ ("exports", ModuleHeader.Exports)
+        , ("single",  ModuleHeader.Single)
+        , ("inline",  ModuleHeader.Inline)
+        , ("always",  ModuleHeader.Always)
+        ]
 
 --------------------------------------------------------------------------------
 parseSimpleAlign :: Config -> A.Object -> A.Parser Step

--- a/lib/Language/Haskell/Stylish/Printer.hs
+++ b/lib/Language/Haskell/Stylish/Printer.hs
@@ -41,6 +41,7 @@ module Language.Haskell.Stylish.Printer
   , removeLineComment
   , sep
   , groupAttachedComments
+  , groupWithoutComments
   , space
   , spaces
   , suffix
@@ -73,7 +74,7 @@ import           Control.Monad.Reader            (MonadReader, ReaderT(..), asks
 import           Control.Monad.State             (MonadState, State)
 import           Control.Monad.State             (runState)
 import           Control.Monad.State             (get, gets, modify, put)
-import           Data.Foldable                   (find)
+import           Data.Foldable                   (find, toList)
 import           Data.Functor                    ((<&>))
 import           Data.List                       (delete, isPrefixOf)
 import           Data.List.NonEmpty              (NonEmpty(..))
@@ -426,6 +427,17 @@ groupAttachedComments = go
       pure $ (comments, L rspan x :| sameGroupOf nextGroupStartM) : restGroups
 
     go _ = pure []
+
+-- | A view on 'groupAttachedComments': return 'Just' when there is just a
+--   one big group without any comments.
+groupWithoutComments
+    :: [([AnnotationComment], NonEmpty (Located a))]
+    -> Maybe [Located a]
+groupWithoutComments grouped
+    | all (null . fst) grouped
+    = Just $ concatMap (toList . snd) grouped
+    | otherwise
+    = Nothing
 
 modifyCurrentLine :: (String -> String) -> P ()
 modifyCurrentLine f = do

--- a/tests/Language/Haskell/Stylish/Step/ModuleHeader/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/ModuleHeader/Tests.hs
@@ -29,26 +29,38 @@ tests = testGroup "Language.Haskell.Stylish.Printer.ModuleHeader"
     , testCase "Exports module" ex9
     , testCase "Exports symbol" ex10
     , testCase "Respects groups" ex11
-    , testCase "'where' not repeated when not part of exports with break_only_where" ex12
-    , testCase "Indents absent export list with 2 spaces with break_only_where" ex13
+    , testCase "'where' not repeated when not part of exports with always break_where" ex12
+    , testCase "Indents absent export list with 2 spaces with always break_where" ex13
     , testCase "Indents with 2 spaces" ex14
     , testCase "Group doc with 2 spaces" ex15
     , testCase "Does not sort" ex16
     , testCase "Repects separate_lists" ex17
-    , testCase "Indents absent export list with break_only_where" ex18
+    , testCase "Indents absent export list with always break_where" ex18
     , testCase "Respects bundled patterns" ex19
+    , testCase "Inline no export list" ex20
+    , testCase "Inline empty export list" ex21
+    , testCase "Inline single export" ex22
+    , testCase "Inline single line sorts" ex23
+    , testCase "Inline breaks when too long" ex24
+    , testCase "Inline single line when no max cols" ex25
+    , testCase "Inline breaks when comments present" ex26
+    , testCase "Single no export list" ex27
+    , testCase "Single empty export list" ex28
+    , testCase "Single one export" ex29
+    , testCase "Single two exports" ex30
+    , testCase "Single one export with comment" ex31
     ]
 
 --------------------------------------------------------------------------------
 ex0 :: Assertion
-ex0 = assertSnippet (step defaultConfig) input input
+ex0 = assertSnippet (step Nothing defaultConfig) input input
   where
     input =
       [ "module Foo where"
       ]
 
 ex1 :: Assertion
-ex1 = assertSnippet (step defaultConfig)
+ex1 = assertSnippet (step Nothing defaultConfig)
     [ "module Foo () where"
     ]
     [ "module Foo"
@@ -57,7 +69,7 @@ ex1 = assertSnippet (step defaultConfig)
     ]
 
 ex2 :: Assertion
-ex2 = assertSnippet (step defaultConfig)
+ex2 = assertSnippet (step Nothing defaultConfig)
     [ "module Foo (tests) where"
     ]
     [ "module Foo"
@@ -66,7 +78,7 @@ ex2 = assertSnippet (step defaultConfig)
     ]
 
 ex3 :: Assertion
-ex3 = assertSnippet (step defaultConfig)
+ex3 = assertSnippet (step Nothing defaultConfig)
     [ "module Foo (t1, t2, t3) where"
     ]
     [ "module Foo"
@@ -77,7 +89,7 @@ ex3 = assertSnippet (step defaultConfig)
     ]
 
 ex4 :: Assertion
-ex4 = assertSnippet (step defaultConfig)
+ex4 = assertSnippet (step Nothing defaultConfig)
     [ "module Foo ("
     , "  t1,"
     , "  t3,"
@@ -102,7 +114,7 @@ ex4 = assertSnippet (step defaultConfig)
     ]
 
 ex5 :: Assertion
-ex5 = assertSnippet (step defaultConfig)
+ex5 = assertSnippet (step Nothing defaultConfig)
     [ "{-# LANGUAGE DerivingVia #-}"
     , "-- | This module docs"
     , "module Foo ("
@@ -121,7 +133,7 @@ ex5 = assertSnippet (step defaultConfig)
     ]
 
 ex6 :: Assertion
-ex6 = assertSnippet (step defaultConfig)
+ex6 = assertSnippet (step Nothing defaultConfig)
     [ "-- | This module docs"
     , "{-# LANGUAGE DerivingVia #-}"
     , "module Foo ("
@@ -140,7 +152,7 @@ ex6 = assertSnippet (step defaultConfig)
     ]
 
 ex7 :: Assertion
-ex7 = assertSnippet (step defaultConfig)
+ex7 = assertSnippet (step Nothing defaultConfig)
     [ "module Foo -- Foo"
     , "("
     , " -- * t1 something"
@@ -163,7 +175,7 @@ ex7 = assertSnippet (step defaultConfig)
 
 
 ex8 :: Assertion
-ex8 = assertSnippet (step defaultConfig)
+ex8 = assertSnippet (step Nothing defaultConfig)
     [ "module Foo ("
     , " -- * t1 something"
     , "  t3,"
@@ -186,7 +198,7 @@ ex8 = assertSnippet (step defaultConfig)
     ]
 
 ex9 :: Assertion
-ex9 = assertSnippet (step defaultConfig)
+ex9 = assertSnippet (step Nothing defaultConfig)
     [ "module Foo ("
     , " -- * t1 something"
     , "  module A,"
@@ -207,7 +219,7 @@ ex9 = assertSnippet (step defaultConfig)
     ]
 
 ex10 :: Assertion
-ex10 = assertSnippet (step defaultConfig)
+ex10 = assertSnippet (step Nothing defaultConfig)
     [ "module Foo ("
     , "  (<&>)"
     , ") where -- x"
@@ -220,7 +232,7 @@ ex10 = assertSnippet (step defaultConfig)
     ]
 
 ex11 :: Assertion
-ex11 = assertSnippet (step defaultConfig)
+ex11 = assertSnippet (step Nothing defaultConfig)
     [ "module Foo ("
     , "  -- group 1"
     , " g1_1,"
@@ -241,7 +253,7 @@ ex11 = assertSnippet (step defaultConfig)
     ]
 
 ex12 :: Assertion
-ex12 = assertSnippet (step defaultConfig {breakOnlyWhere = True})
+ex12 = assertSnippet (step Nothing defaultConfig {breakWhere = Always})
     [ "module Foo"
     , "  where"
     , "-- hmm"
@@ -252,7 +264,7 @@ ex12 = assertSnippet (step defaultConfig {breakOnlyWhere = True})
     ]
 
 ex13 :: Assertion
-ex13 = assertSnippet (step defaultConfig {breakOnlyWhere = True, indent = 2})
+ex13 = assertSnippet (step Nothing defaultConfig {breakWhere = Always, indent = 2})
     [ "module Foo where"
     ]
     [ "module Foo"
@@ -260,7 +272,7 @@ ex13 = assertSnippet (step defaultConfig {breakOnlyWhere = True, indent = 2})
     ]
 
 ex14 :: Assertion
-ex14 = assertSnippet (step defaultConfig {indent = 2})
+ex14 = assertSnippet (step Nothing defaultConfig {indent = 2})
     [ "module Foo"
     , "  ( yes"
     , "  , no"
@@ -273,7 +285,7 @@ ex14 = assertSnippet (step defaultConfig {indent = 2})
     ]
 
 ex15 :: Assertion
-ex15 = assertSnippet (step defaultConfig {indent = 2})
+ex15 = assertSnippet (step Nothing defaultConfig {indent = 2})
     [ "module Foo -- Foo"
     , "("
     , " -- * t1 something"
@@ -293,7 +305,7 @@ ex15 = assertSnippet (step defaultConfig {indent = 2})
     ]
 
 ex16 :: Assertion
-ex16 = assertSnippet (step defaultConfig {sort = False}) input input
+ex16 = assertSnippet (step Nothing defaultConfig {sort = False}) input input
   where
     input =
       [ "module Foo"
@@ -303,7 +315,7 @@ ex16 = assertSnippet (step defaultConfig {sort = False}) input input
       ]
 
 ex17 :: Assertion
-ex17 = assertSnippet (step defaultConfig {separateLists = False})
+ex17 = assertSnippet (step Nothing defaultConfig {separateLists = False})
     [ "module Foo"
     , "    ( Bar (..)"
     , "    ) where"
@@ -314,7 +326,7 @@ ex17 = assertSnippet (step defaultConfig {separateLists = False})
     ]
 
 ex18 :: Assertion
-ex18 = assertSnippet (step defaultConfig {breakOnlyWhere = True})
+ex18 = assertSnippet (step Nothing defaultConfig {breakWhere = Always})
     [ "module Foo where"
     ]
     [ "module Foo"
@@ -322,12 +334,136 @@ ex18 = assertSnippet (step defaultConfig {breakOnlyWhere = True})
     ]
 
 ex19 :: Assertion
-ex19 = assertSnippet (step defaultConfig)
+ex19 = assertSnippet (step Nothing defaultConfig)
     [ "{-# LANGUAGE PatternSynonyms #-}"
     , "module Foo (Bar (.., Baz)) where"
     ]
     [ "{-# LANGUAGE PatternSynonyms #-}"
     , "module Foo"
     , "    ( Bar (.., Baz)"
+    , "    ) where"
+    ]
+
+ex20 :: Assertion
+ex20 = assertSnippet (step (Just 80) defaultConfig {breakWhere = Inline})
+    [ "module Foo where"
+    ]
+    [ "module Foo where"
+    ]
+
+ex21 :: Assertion
+ex21 = assertSnippet (step (Just 80) defaultConfig {breakWhere = Inline})
+    [ "module Foo () where"
+    ]
+    [ "module Foo () where"
+    ]
+
+ex22 :: Assertion
+ex22 = assertSnippet (step (Just 80) defaultConfig {breakWhere = Inline})
+    [ "module Foo"
+    , "    ( main"
+    , "    ) where"
+    ]
+    [ "module Foo (main) where"
+    ]
+
+ex23 :: Assertion
+ex23 = assertSnippet (step (Just 80) defaultConfig {breakWhere = Inline})
+    [ "{-# LANGUAGE PatternSynonyms #-}"
+    , "module Foo"
+    , "    ( Foo(MkFoo)"
+    , "    , Bar (.., Baz)"
+    , "    ) where"
+    ]
+    [ "{-# LANGUAGE PatternSynonyms #-}"
+    , "module Foo (Bar (.., Baz), Foo (MkFoo)) where"
+    ]
+
+ex24 :: Assertion
+ex24 = assertSnippet (step (Just 80) defaultConfig {breakWhere = Inline})
+    [ "module LongModuleName (longExportName1, longExportName2, longExportName3, longExportName4) where"
+    ]
+    [ "module LongModuleName"
+    , "    ( longExportName1"
+    , "    , longExportName2"
+    , "    , longExportName3"
+    , "    , longExportName4"
+    , "    ) where"
+    ]
+
+ex25 :: Assertion
+ex25 = assertSnippet (step Nothing defaultConfig {breakWhere = Inline})
+    [ "module LongModuleName (longExportName1, longExportName2, longExportName3, longExportName4) where"
+    ]
+    [ "module LongModuleName (longExportName1, longExportName2, longExportName3, longExportName4) where"
+    ]
+
+ex26 :: Assertion
+ex26 = assertSnippet (step (Just 80) defaultConfig {breakWhere = Inline})
+    [ "module Foo ("
+    , " -- * t1 something"
+    , "  module A,"
+    , "  t3,"
+    , " -- * t2 something"
+    , "  t2"
+    , ") where -- x"
+    , "-- y"
+    ]
+    [ "module Foo"
+    , "    ( -- * t1 something"
+    , "      module A"
+    , "    , t3"
+    , "      -- * t2 something"
+    , "    , t2"
+    , "    ) where -- x"
+    , "-- y"
+    ]
+
+ex27 :: Assertion
+ex27 = assertSnippet (step Nothing defaultConfig {breakWhere = Single})
+    [ "module Foo where"
+    ]
+    [ "module Foo where"
+    ]
+
+ex28 :: Assertion
+ex28 = assertSnippet (step Nothing defaultConfig {breakWhere = Single})
+    [ "module Foo () where"
+    ]
+    [ "module Foo () where"
+    ]
+
+ex29 :: Assertion
+ex29 = assertSnippet (step Nothing defaultConfig {breakWhere = Single})
+    [ "module Foo"
+    , "    ( main"
+    , "    ) where"
+    ]
+    [ "module Foo (main) where"
+    ]
+
+ex30 :: Assertion
+ex30 = assertSnippet (step Nothing defaultConfig {breakWhere = Single})
+    [ "module Foo"
+    , "    ( bar"
+    , "    , foo"
+    , "    ) where"
+    ]
+    [ "module Foo"
+    , "    ( bar"
+    , "    , foo"
+    , "    ) where"
+    ]
+
+ex31 :: Assertion
+ex31 = assertSnippet (step Nothing defaultConfig {breakWhere = Single})
+    [ "module Foo"
+    , "    ( -- * Foo"
+    , "      Foo"
+    , "    ) where"
+    ]
+    [ "module Foo"
+    , "    ( -- * Foo"
+    , "      Foo"
     , "    ) where"
     ]


### PR DESCRIPTION
Previously, the `break_only_where` option of `module_header` allowed choosing
between the following two styles:

1. `break_only_where: false`:

   ```haskell
   module Foo where

   module Bar
       ( main
       ) where
   ```

2. `break_only_where: true`:

   ```haskell
   module Foo
       where

   module Bar
       ( main
       ) where
   ```

In case a module only has a single export (e.g., `main` or `tests`) or no
exports at all (e.g., a module defining orphans), we still "break" the `where`:

```haskell
module Bar
    ( main
    ) where
module Orphans
    (
    ) where
```

It should be possible to print these module headers as:

```haskell
module Bar (main) where
module Orphans () where
```

We generalise the `break_only_where` option to `break_where` with the following
three possible values:

- `exports`: only break when there is an explicit export list.
- `inline`: only break when the export list is too long. This is determined by
   the `columns` setting. Not applicable when the export list contains comments
   as newlines will be required.
- `always`: always break before the `where`.