### PR TITLE
Dump AST

### DIFF
--- a/tests/Language/Haskell/Stylish/Tests/Util.hs
+++ b/tests/Language/Haskell/Stylish/Tests/Util.hs
@@ -39,6 +39,12 @@ import           Language.Haskell.Stylish.Step
 import           Language.Haskell.Stylish.Module (Module)
 
 --------------------------------------------------------------------------------
+-- | Takes a Haskell source as an argument and parse it into a Module.
+-- Extract function selects element from that Module record and returns
+-- its String representation.
+--
+-- This function should be used when trying to understand how particular
+-- Haskell code will be represented by ghc-parser's AST
 dumpAst :: Data a => (Module -> a) -> String -> String
 dumpAst extract str =
   let Right(theModule) = parseModule [] Nothing str

--- a/tests/Language/Haskell/Stylish/Tests/Util.hs
+++ b/tests/Language/Haskell/Stylish/Tests/Util.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE TypeFamilies   #-}
 module Language.Haskell.Stylish.Tests.Util
-    ( testStep
+    ( dumpAst
+    , dumpModule
+    , testStep
     , testStep'
     , Snippet (..)
     , testSnippet
@@ -16,6 +18,8 @@ import           Control.Exception              (bracket, try)
 import           Control.Monad.Writer           (execWriter, tell)
 import           Data.List                      (intercalate)
 import           GHC.Exts                       (IsList (..))
+import           GHC.Hs.Dump                    (showAstData, BlankSrcSpan(..))
+import           Language.Haskell.Stylish.GHC   (baseDynFlags)
 import           System.Directory               (createDirectory,
                                                  getCurrentDirectory,
                                                  getTemporaryDirectory,
@@ -26,12 +30,24 @@ import           System.IO.Error                (isAlreadyExistsError)
 import           System.Random                  (randomIO)
 import           Test.HUnit                     (Assertion, assertFailure,
                                                  (@=?))
-
+import           Outputable                     (showSDoc)
+import           Data.Data                      (Data(..))
 
 --------------------------------------------------------------------------------
 import           Language.Haskell.Stylish.Parse
 import           Language.Haskell.Stylish.Step
+import           Language.Haskell.Stylish.Module (Module)
 
+--------------------------------------------------------------------------------
+dumpAst :: Data a => (Module -> a) -> String -> String
+dumpAst extract str =
+  let Right(theModule) = parseModule [] Nothing str
+      ast              = extract theModule
+      sdoc             = showAstData BlankSrcSpan ast
+  in  showSDoc baseDynFlags sdoc
+
+dumpModule :: String -> String
+dumpModule = dumpAst id
 
 --------------------------------------------------------------------------------
 testStep :: Step -> String -> String


### PR DESCRIPTION
Change 

```
case01 :: Assertion
case01 = expected @=? testStep (step indentIndentStyle) input
  where
    input = unlines
      [ "module Herp where"
      , ""
      , "data Foo = Foo { a :: Int }"
      ]

    expected = unlines
       [ "module Herp where"
       , ""
       , "data Foo"
       , "  = Foo"
       , "      { a :: Int"
       , "      }"
       ]
```

to

```
case01 :: Assertion
case01 = assertFailure $ dumpAst parsedModule input
  where
    input = unlines
      [ "module Herp where"
      , ""
      , "data Foo = Foo { a :: Int }"
      ]
```

then run it with

```
cabal run stylish-haskell-tests
```

to get

```
({ ss }
 (HsModule
  (Just
   ({ ss }
    {ModuleName: Herp}))
  (Nothing)
  []
  [({ ss }
    (TyClD
     (NoExtField)
     (DataDecl
      (NoExtField)
      ({ ss }
       (Unqual
        {OccName: Foo}))
      (HsQTvs
       (NoExtField)
       [])
      (Prefix)
      (HsDataDefn
       (NoExtField)
       (DataType)
       ({ ss }
        [])
       (Nothing)
       (Nothing)
       [({ ss }
         (ConDeclH98
          (NoExtField)
          ({ ss }
           (Unqual
            {OccName: Foo}))
          ({ ss }
           (False))
          []
          (Nothing)
          (RecCon
           ({ ss }
            [({ ss }
              (ConDeclField
               (NoExtField)
               [({ ss }
                 (FieldOcc
                  (NoExtField)
                  ({ ss }
                   (Unqual
                    {OccName: a}))))]
               ({ ss }
                (HsTyVar
                 (NoExtField)
                 (NotPromoted)
                 ({ ss }
                  (Unqual
                   {OccName: Int}))))
               (Nothing)))]))
          (Nothing)))]
       ({ ss }
        [])))))]
```